### PR TITLE
Add message after user action

### DIFF
--- a/modals/add-dialog.html
+++ b/modals/add-dialog.html
@@ -17,6 +17,6 @@
 
 <p role="status" id="add-form-errors" class="ally-wb-edit-form-errors"></p>
 
-<p role="status" id="form-success-message" class="ally-wb-edit-form-success"></p>
+<p role="alert" id="form-success-message" class="ally-wb-edit-form-success"></p>
 
 <script type="module" src="add-dialog.js"></script>

--- a/modals/add-dialog.html
+++ b/modals/add-dialog.html
@@ -15,7 +15,7 @@
     </div>
 </form>
 
-<p role="status" id="add-form-errors" class="ally-wb-edit-form-errors"></p>
+<p role="status" id="form-failure-message" class="ally-wb-edit-form-errors"></p>
 
 <p role="alert" id="form-success-message" class="ally-wb-edit-form-success"></p>
 

--- a/modals/add-dialog.html
+++ b/modals/add-dialog.html
@@ -17,4 +17,6 @@
 
 <p role="status" id="add-form-errors" class="ally-wb-edit-form-errors"></p>
 
+<p role="status" id="form-success-message" class="ally-wb-edit-form-success"></p>
+
 <script type="module" src="add-dialog.js"></script>

--- a/modals/add-dialog.js
+++ b/modals/add-dialog.js
@@ -1,3 +1,4 @@
+import { handleError } from './handle-error'
 import { handleToast } from './handle-toast'
 import { getInputElement } from './input-elements'
 import { onToggleColorInput } from './toggle-color-input'
@@ -49,31 +50,36 @@ form.addEventListener('submit', async (event) => {
     const formData = new FormData(form)
     const dataType = formFields.getAttribute(ITEM_TYPE_KEY)
 
-    if (dataType === 'frame') {
-        await miro.board.createFrame({
-            title: formData.get('title'),
-            style: {
-                fillColor: formData.get('style.fillColor') ?? 'transparent'
-            },
-            width: +formData.get('width'),
-            height: +formData.get('height')
-        })
-    }
+    try {
+        if (dataType === 'frame') {
+            await miro.board.createFrame({
+                title: formData.get('title'),
+                style: {
+                    fillColor: formData.get('style.fillColor') ?? 'transparent'
+                },
+                width: +formData.get('width'),
+                height: +formData.get('height')
+            })
+        }
 
-    if (dataType === 'sticky_note') {
-        await miro.board.createStickyNote({
-            content: formData.get('content'),
-            style: {
-                fillColor: formData.get('style.fillColor')
-            },
-        })
-    }
+        if (dataType === 'sticky_note') {
+            await miro.board.createStickyNote({
+                content: formData.get('content'),
+                style: {
+                    fillColor: formData.get('style.fillColor')
+                },
+            })
+        }
 
-    if (dataType === 'text') {
-        await miro.board.createText({
-            content: formData.get('content'),
-        })
-    }
+        if (dataType === 'text') {
+            await miro.board.createText({
+                content: formData.get('content'),
+            })
+        }
 
-    handleToast('Item added')
+        handleToast('Item added')
+    } catch (error) {
+        console.error('Error adding item: ', error.message)
+        handleError('Error adding item')
+    }
 })

--- a/modals/add-dialog.js
+++ b/modals/add-dialog.js
@@ -1,3 +1,4 @@
+import { handleToast } from './handle-toast'
 import { getInputElement } from './input-elements'
 import { onToggleColorInput } from './toggle-color-input'
 
@@ -74,5 +75,5 @@ form.addEventListener('submit', async (event) => {
         })
     }
 
-    await miro.board.ui.closeModal()
+    handleToast('Item added')
 })

--- a/modals/delete-dialog.html
+++ b/modals/delete-dialog.html
@@ -19,6 +19,8 @@
         </button>
     </div>
 
+    <p role="status" id="form-failure-message" class="ally-wb-edit-form-errors"></p>
+
     <p role="alert" id="form-success-message" class="ally-wb-edit-form-success"></p>
 </main>
 

--- a/modals/delete-dialog.html
+++ b/modals/delete-dialog.html
@@ -19,7 +19,7 @@
         </button>
     </div>
 
-    <p role="status" id="form-success-message" class="ally-wb-edit-form-success"></p>
+    <p role="alert" id="form-success-message" class="ally-wb-edit-form-success"></p>
 </main>
 
 <script type="module" src="delete-dialog.js"></script>

--- a/modals/delete-dialog.html
+++ b/modals/delete-dialog.html
@@ -18,6 +18,8 @@
             Cancel
         </button>
     </div>
+
+    <p role="status" id="form-success-message" class="ally-wb-edit-form-success"></p>
 </main>
 
 <script type="module" src="delete-dialog.js"></script>

--- a/modals/delete-dialog.js
+++ b/modals/delete-dialog.js
@@ -1,3 +1,4 @@
+import { handleError } from "./handle-error"
 import { handleToast } from "./handle-toast"
 
 const title = document.querySelector('#dialog-title')
@@ -15,9 +16,16 @@ const modalData = fetchModalData().then((data) => {
 
 deleteButton.addEventListener('click', async () => {
     const itemId = deleteButton.getAttribute(ITEM_ID_KEY)
-    const item = await miro.board.getById(itemId)
-    await miro.board.remove(item)
-    handleToast('Item deleted')
+
+    try {
+        const item = await miro.board.getById(itemId)
+        await miro.board.remove(item)
+        handleToast('Item deleted')
+    } catch (error) {
+        console.error('Error deleting item: ', error)
+        handleError('Error deleting item')
+    }
+
 })
 
 cancelButton.addEventListener('click', async () => {

--- a/modals/delete-dialog.js
+++ b/modals/delete-dialog.js
@@ -1,3 +1,5 @@
+import { handleToast } from "./handle-toast"
+
 const title = document.querySelector('#dialog-title')
 
 const deleteButton = document.querySelector('#delete-dialog-delete-button')
@@ -15,7 +17,7 @@ deleteButton.addEventListener('click', async () => {
     const itemId = deleteButton.getAttribute(ITEM_ID_KEY)
     const item = await miro.board.getById(itemId)
     await miro.board.remove(item)
-    await miro.board.ui.closeModal()
+    handleToast('Item deleted')
 })
 
 cancelButton.addEventListener('click', async () => {

--- a/modals/edit-dialog.html
+++ b/modals/edit-dialog.html
@@ -15,7 +15,7 @@
     </div>
 </form>
 
-<p role="status" id="edit-form-errors" class="ally-wb-edit-form-errors"></p>
+<p role="status" id="form-failure-message" class="ally-wb-edit-form-errors"></p>
 
 <p role="alert" id="form-success-message" class="ally-wb-edit-form-success"></p>
 

--- a/modals/edit-dialog.html
+++ b/modals/edit-dialog.html
@@ -17,6 +17,6 @@
 
 <p role="status" id="edit-form-errors" class="ally-wb-edit-form-errors"></p>
 
-<p role="status" id="form-success-message" class="ally-wb-edit-form-success"></p>
+<p role="alert" id="form-success-message" class="ally-wb-edit-form-success"></p>
 
 <script type="module" src="edit-dialog.js"></script>

--- a/modals/edit-dialog.html
+++ b/modals/edit-dialog.html
@@ -17,4 +17,6 @@
 
 <p role="status" id="edit-form-errors" class="ally-wb-edit-form-errors"></p>
 
+<p role="status" id="form-success-message" class="ally-wb-edit-form-success"></p>
+
 <script type="module" src="edit-dialog.js"></script>

--- a/modals/edit-dialog.js
+++ b/modals/edit-dialog.js
@@ -1,6 +1,7 @@
 import { getInputElement } from './input-elements'
 import { onToggleColorInput } from './toggle-color-input'
 import { handleToast } from './handle-toast'
+import { handleError } from './handle-error'
 
 const title = document.querySelector('#dialog-title')
 
@@ -31,33 +32,30 @@ form.addEventListener('submit', async (event) => {
     const formData = new FormData(form)
     const itemId = formFields.getAttribute(ITEM_ID_KEY)
 
-    if (itemId) {
+    try {
         const item = await miro.board.getById(itemId)
+        const formFieldNames = formData.keys()
 
-        if (item) {
-            const formFieldNames = formData.keys()
-            for (const formFieldName of formFieldNames) {
-                // Handle nested field names, like style.fillColor
-                const formFieldNameChildren = formFieldName.split('.')
-                const lastFieldName = formFieldNameChildren.pop()
-                let currentFieldName = item
+        for (const formFieldName of formFieldNames) {
+            // Handle nested field names, like style.fillColor
+            const formFieldNameChildren = formFieldName.split('.')
+            const lastFieldName = formFieldNameChildren.pop()
+            let currentFieldName = item
 
-                for (const fieldNameChild of formFieldNameChildren) {
-                    if (!currentFieldName[fieldNameChild]) {
-                        currentFieldName[fieldNameChild] = {}
-                    }
-                    currentFieldName = currentFieldName[fieldNameChild]
+            for (const fieldNameChild of formFieldNameChildren) {
+                if (!currentFieldName[fieldNameChild]) {
+                    currentFieldName[fieldNameChild] = {}
                 }
-                currentFieldName[lastFieldName] = formData.get(formFieldName)
+                currentFieldName = currentFieldName[fieldNameChild]
             }
-
-            await item.sync()
-            window.sessionStorage.setItem('updated_miro_items', JSON.stringify([item]))
-            handleToast('Item edited')
-        } else {
-            console.error('Error loading item')
+            currentFieldName[lastFieldName] = formData.get(formFieldName)
         }
-    } else {
-        console.error('Missing item ID')
+
+        await item.sync()
+        window.sessionStorage.setItem('updated_miro_items', JSON.stringify([item]))
+        handleToast('Item edited')
+    } catch (error) {
+        console.error('Error editing item: ', error)
+        handleError('Error editing item')
     }
 })

--- a/modals/edit-dialog.js
+++ b/modals/edit-dialog.js
@@ -1,5 +1,6 @@
 import { getInputElement } from './input-elements'
 import { onToggleColorInput } from './toggle-color-input'
+import { handleToast } from './handle-toast'
 
 const title = document.querySelector('#dialog-title')
 
@@ -52,7 +53,7 @@ form.addEventListener('submit', async (event) => {
 
             await item.sync()
             window.sessionStorage.setItem('updated_miro_items', JSON.stringify([item]))
-            await miro.board.ui.closeModal()
+            handleToast('Item edited')
         } else {
             console.error('Error loading item')
         }

--- a/modals/handle-error.js
+++ b/modals/handle-error.js
@@ -1,0 +1,7 @@
+const failureMessage = document.querySelector('#form-failure-message')
+
+export const handleError = (message) => {
+    if (failureMessage) {
+        failureMessage.textContent = message
+    }
+}

--- a/modals/handle-toast.js
+++ b/modals/handle-toast.js
@@ -1,0 +1,11 @@
+const successMessage = document.querySelector('#form-success-message')
+
+export const handleToast = (message) => {
+    if (successMessage) {
+        successMessage.textContent = message
+    
+        // setTimeout(async () => {
+        //     await miro.board.ui.closeModal()
+        // }, 3000)
+    }
+}

--- a/modals/handle-toast.js
+++ b/modals/handle-toast.js
@@ -4,8 +4,8 @@ export const handleToast = (message) => {
     if (successMessage) {
         successMessage.textContent = message
     
-        // setTimeout(async () => {
-        //     await miro.board.ui.closeModal()
-        // }, 3000)
+        setTimeout(async () => {
+            await miro.board.ui.closeModal()
+        }, 3000)
     }
 }

--- a/modals/move-dialog.html
+++ b/modals/move-dialog.html
@@ -13,6 +13,6 @@
     <li>No frames available</li>
 </ul>
 
-<p role="status" id="form-success-message" class="ally-wb-edit-form-success"></p>
+<p role="alert" id="form-success-message" class="ally-wb-edit-form-success"></p>
 
 <script type="module" src="./move-dialog.js"></script>

--- a/modals/move-dialog.html
+++ b/modals/move-dialog.html
@@ -13,6 +13,8 @@
     <li>No frames available</li>
 </ul>
 
+<p role="status" id="form-failure-message" class="ally-wb-edit-form-errors"></p>
+
 <p role="alert" id="form-success-message" class="ally-wb-edit-form-success"></p>
 
 <script type="module" src="./move-dialog.js"></script>

--- a/modals/move-dialog.html
+++ b/modals/move-dialog.html
@@ -13,4 +13,6 @@
     <li>No frames available</li>
 </ul>
 
+<p role="status" id="form-success-message" class="ally-wb-edit-form-success"></p>
+
 <script type="module" src="./move-dialog.js"></script>

--- a/modals/move-dialog.js
+++ b/modals/move-dialog.js
@@ -1,3 +1,5 @@
+import { handleToast } from "./handle-toast"
+
 const frames = []
 
 const fetchModalData = async () => await miro.board.ui.getModalData()
@@ -41,7 +43,7 @@ const moveToFrame = async (itemId, frameId) => {
         }
     ]))
 
-    await miro.board.ui.closeModal()
+    handleToast('Item moved')
 }
 
 const removeFromFrame = async (itemId) => {

--- a/modals/move-dialog.js
+++ b/modals/move-dialog.js
@@ -1,3 +1,4 @@
+import { handleError } from "./handle-error"
 import { handleToast } from "./handle-toast"
 
 const frames = []
@@ -20,52 +21,62 @@ fetchFrames()
 const framesList = document.querySelector('#move-form-available-frames-list')
 
 const moveToFrame = async (itemId, frameId) => {
-    const frame = await miro.board.getById(frameId)
-    const item = await miro.board.getById(itemId)
+    try {
+        const frame = await miro.board.getById(frameId)
+        const item = await miro.board.getById(itemId)
 
-    // Move the item inside of the frame
-    item.x = frame.x + 1
-    item.y = frame.y + 1
-    await item.sync()
+        // Move the item inside of the frame
+        item.x = frame.x + 1
+        item.y = frame.y + 1
+        await item.sync()
 
-    // Add to frame
-    await frame.add(item)
+        // Add to frame
+        await frame.add(item)
 
-    // Sync with panel
-    window.sessionStorage.setItem('updated_miro_items', JSON.stringify([
-        {
-            ...frame,
-            childrenIds: [...frame.childrenIds, item.id]
-        },
-        {
-            ...item,
-            parentId: frame.id
-        }
-    ]))
+        // Sync with panel
+        window.sessionStorage.setItem('updated_miro_items', JSON.stringify([
+            {
+                ...frame,
+                childrenIds: [...frame.childrenIds, item.id]
+            },
+            {
+                ...item,
+                parentId: frame.id
+            }
+        ]))
 
-    handleToast('Item moved')
+        handleToast('Item moved')
+    } catch (error) {
+        console.error('Error moving item: ', error)
+        handleError('Error moving item')
+    }
 }
 
 const removeFromFrame = async (itemId) => {
-    const item = await miro.board.getById(itemId)
-    const frame = await miro.board.getById(item.parentId)
+    try {
+        const item = await miro.board.getById(itemId)
+        const frame = await miro.board.getById(item.parentId)
 
-    // Add to frame
-    await frame.remove(item)
+        // Add to frame
+        await frame.remove(item)
 
-    // Sync with panel
-    window.sessionStorage.setItem('updated_miro_items', JSON.stringify([
-        {
-            ...frame,
-            childrenIds: frame.childrenIds.filter(child => child !== item.id)
-        },
-        {
-            ...item,
-            parentId: null
-        }
-    ]))
+        // Sync with panel
+        window.sessionStorage.setItem('updated_miro_items', JSON.stringify([
+            {
+                ...frame,
+                childrenIds: frame.childrenIds.filter(child => child !== item.id)
+            },
+            {
+                ...item,
+                parentId: null
+            }
+        ]))
 
-    await miro.board.ui.closeModal()
+        handleToast('Item moved')
+    } catch (error) {
+        console.error('Error moving item: ', error)
+        handleError('Error moving item')
+    }
 }
 
 const getFrameListItem = (item, frame) => {

--- a/src/styles/components/edit-form.css
+++ b/src/styles/components/edit-form.css
@@ -49,6 +49,11 @@
     font-weight: bold;
 }
 
+.ally-wb-edit-form-success {
+    color: green;
+    font-weight: bold;
+}
+
 .ally-wb-hidden {
     display: none;
 }


### PR DESCRIPTION
Fix for issue: #9

This adds a status message (i.e. polite level of assertion) for screen readers after the user has completed an action (i.e. clicked the submit button).

The Miro SDK does not actually present us with a way to know if the action a user took was successful or not (i.e. the call to sync the board is always `undefined`), so the message always reads as successful.

Additionally, we no longer automatically close the form modal because the correct level of assertion for a success message is just a status, but we can't be sure that the screen reader user will be able to hear the message in time before the modal closes. This makes it safer to not automatically close the modal. WCAG reference: [Technique G199](https://www.w3.org/WAI/WCAG21/Techniques/general/G199)