### PR TITLE
Focus on title

### DIFF
--- a/modals/add-dialog.html
+++ b/modals/add-dialog.html
@@ -2,7 +2,7 @@
 <script src="https://miro.com/app/static/sdk/v2/miro.js"></script>
 
 <header class="ally-wb-edit-form-header">
-    <h2 id="dialog-title">Add</h2>
+    <h2 id="dialog-title" tabindex="-1">Add</h2>
 </header>
 
 <form id="add-form" class="ally-wb-edit-form-form">

--- a/modals/add-dialog.js
+++ b/modals/add-dialog.js
@@ -3,6 +3,10 @@ import { onToggleColorInput } from './toggle-color-input'
 
 const title = document.querySelector('#dialog-title')
 
+window.addEventListener('DOMContentLoaded', () => {
+  title?.focus()
+})
+
 const formFields = document.querySelector('#add-form-fields')
 const formInputs = []
 const formErrors = document.querySelector('#add-form-errors')

--- a/modals/delete-dialog.html
+++ b/modals/delete-dialog.html
@@ -2,7 +2,7 @@
 <script src="https://miro.com/app/static/sdk/v2/miro.js"></script>
 
 <header class="ally-wb-delete-dialog-header">
-    <h2 id="dialog-title">Delete</h2>
+    <h2 id="dialog-title" tabindex="-1">Delete</h2>
 </header>
 
 <main>

--- a/modals/delete-dialog.js
+++ b/modals/delete-dialog.js
@@ -1,5 +1,9 @@
 const title = document.querySelector('#dialog-title')
 
+window.addEventListener('DOMContentLoaded', () => {
+  title?.focus()
+})
+
 const deleteButton = document.querySelector('#delete-dialog-delete-button')
 const cancelButton = document.querySelector('#delete-dialog-cancel-button')
 

--- a/modals/edit-dialog.html
+++ b/modals/edit-dialog.html
@@ -2,7 +2,7 @@
 <script src="https://miro.com/app/static/sdk/v2/miro.js"></script>
 
 <header class="ally-wb-edit-form-header">
-    <h2 id="dialog-title">Edit</h2>
+    <h2 id="dialog-title" tabindex="-1">Edit</h2>
 </header>
 
 <form id="edit-form" class="ally-wb-edit-form-form">

--- a/modals/edit-dialog.js
+++ b/modals/edit-dialog.js
@@ -3,6 +3,10 @@ import { onToggleColorInput } from './toggle-color-input'
 
 const title = document.querySelector('#dialog-title')
 
+window.addEventListener('DOMContentLoaded', () => {
+  title?.focus()
+})
+
 const formFields = document.querySelector('#edit-form-fields')
 const formInputs = []
 const formErrors = document.querySelector('#edit-form-errors')

--- a/modals/move-dialog.html
+++ b/modals/move-dialog.html
@@ -1,7 +1,7 @@
 <link href="../src/styles/index.css" type="text/css" rel="stylesheet" />
 <script src="https://miro.com/app/static/sdk/v2/miro.js"></script>
 
-<h2 id="dialog-title">Move</h2>
+<h2 id="dialog-title" tabindex="-1">Move</h2>
 
 <p id="move-form-move-to-board-container">
 

--- a/modals/move-dialog.js
+++ b/modals/move-dialog.js
@@ -90,6 +90,11 @@ const getFrameListItem = (item, frame) => {
 }
 
 const title = document.querySelector('#dialog-title')
+
+window.addEventListener('DOMContentLoaded', () => {
+  title?.focus()
+})
+
 const moveToBoardContainer = document.querySelector('#move-form-move-to-board-container')
 
 fetchModalData().then(data => {


### PR DESCRIPTION
Fix for issue: #8 

The Miro SDK does not allow us access to the dialog element that modals open in. The correct way to add this functionality would be by indicating an `aria-labelledby` property on the dialog itself and linking that property to the header element (e.g. "Edit Item") in the modal.

Because this is not possible, this implementations attempts to achieve having screen reader users hear the title of the modal first by manually moving the focus to the title.

This has some drawbacks, namely the title is just text and not an interactive element. Because it is not an interactive element, it normally can't be focused on. In this situation, we are adding a tab index to the element so that it can receive focus, but this isn't normal for a text element and could cause unexpected behavior.