### PR TITLE
Fix: New elements should no longer overlap

### DIFF
--- a/modals/components/AddModal.tsx
+++ b/modals/components/AddModal.tsx
@@ -1,12 +1,12 @@
 import { AddModalProperties } from '../../src/models/modals';
-import { Frame, Item, ItemType, StickyNote, StickyNoteColor } from '@mirohq/websdk-types';
+import { Frame, ItemType, StickyNoteColor } from '@mirohq/websdk-types';
 import { FormEvent, useEffect, useState } from 'react';
 import { notifyBoardUpdate } from '../../src/utils/board-sync';
 import { InputElement } from '../inputs/InputElement';
-import { findItemPlacement } from '@utils/item-placer';
 import { parseFloatFromForm } from '@utils/forms';
-import { ConnectableItem } from '@models/item';
-import { isFrame, isStickyNote } from '@utils/items';
+import { ConnectableItem, HierarchyItem } from '@models/item';
+import { isStickyNote } from '@utils/items';
+import { placeItem } from '@utils/item-placer';
 
 type AddModalProps = {
   handleError: (message: string, error: unknown) => void;
@@ -51,27 +51,17 @@ export const AddModal = (props: AddModalProps) => {
 
       await miro.board;
 
-      const parentId = props.modalData.parentId ?? formData.get('parentId');
+      const parentId = formData.get('parentId');
 
       const newItemDimensions = {
         width: parseFloatFromForm(formData.get('width')),
         height: parseFloatFromForm(formData.get('height')),
       };
 
-      let newItemPosition = {
-        x: 0,
-        y: 0,
-      };
-
       let parent: ConnectableItem | null = null;
-
-      if (parentId) {
-        parent = await miro.board.getById(parentId as string) as ConnectableItem;
-        newItemPosition = await findItemPlacement({
-          x: parent.x,
-          y: parent.y,
-          ...newItemDimensions,
-        });
+      
+      if (typeof parentId === 'string') {
+        parent = await miro.board.getById(parentId) as ConnectableItem;
       }
 
       if (dataType === 'frame') {
@@ -80,8 +70,7 @@ export const AddModal = (props: AddModalProps) => {
           style: {
             fillColor: (formData.get('style.fillColor') as string) ?? 'transparent',
           },
-          width: +(formData.get('width') as string),
-          height: +(formData.get('height') as string),
+          ...newItemDimensions,
           x: 0, // for frames we might want to add it relative to the last created frame
           y: 0,
         });
@@ -99,8 +88,8 @@ export const AddModal = (props: AddModalProps) => {
           style: {
             fillColor,
           },
+          ...newItemDimensions,
         });
-
       }
 
       if (dataType === 'text') {
@@ -109,32 +98,12 @@ export const AddModal = (props: AddModalProps) => {
         });
       }
 
-      if (parent && newItem) {
-        newItem.x = newItemPosition.x;
-        newItem.y = newItemPosition.y;
-        await newItem.sync();
-
-        if (isFrame(parent)) {
-          await parent.add(newItem);
-        } else {
-          const connector = await miro.board.createConnector({
-            shape: 'curved',
-            start: {
-              item: parent.id,
-              position: {
-                x: 1.0, // todo: calculate position relative to parent
-                y: 0.5
-              }
-            },
-            end: {
-              item: newItem.id,
-              snapTo: 'auto'  // todo: calculate type relative to parent
-            }
-          });
-        }
-
-        notifyBoardUpdate();
+      if (newItem) {
+        let hierarchyParent: HierarchyItem | undefined = props.modalData.hierarchyItem;
+        await placeItem(newItem, { parent: hierarchyParent });
       }
+
+      notifyBoardUpdate();
 
       handleToast('Item added');
     } catch (error) {

--- a/modals/components/AddModal.tsx
+++ b/modals/components/AddModal.tsx
@@ -1,8 +1,12 @@
 import { AddModalProperties } from '../../src/models/modals';
-import { Frame, ItemType, StickyNoteColor } from '@mirohq/websdk-types';
+import { Frame, Item, ItemType, StickyNote, StickyNoteColor } from '@mirohq/websdk-types';
 import { FormEvent, useEffect, useState } from 'react';
 import { notifyBoardUpdate } from '../../src/utils/board-sync';
 import { InputElement } from '../inputs/InputElement';
+import { findItemPlacement } from '@utils/item-placer';
+import { parseFloatFromForm } from '@utils/forms';
+import { ConnectableItem } from '@models/item';
+import { isFrame, isStickyNote } from '@utils/items';
 
 type AddModalProps = {
   handleError: (message: string, error: unknown) => void;
@@ -45,6 +49,31 @@ export const AddModal = (props: AddModalProps) => {
     try {
       let newItem;
 
+      await miro.board;
+
+      const parentId = props.modalData.parentId ?? formData.get('parentId');
+
+      const newItemDimensions = {
+        width: parseFloatFromForm(formData.get('width')),
+        height: parseFloatFromForm(formData.get('height')),
+      };
+
+      let newItemPosition = {
+        x: 0,
+        y: 0,
+      };
+
+      let parent: ConnectableItem | null = null;
+
+      if (parentId) {
+        parent = await miro.board.getById(parentId as string) as ConnectableItem;
+        newItemPosition = await findItemPlacement({
+          x: parent.x,
+          y: parent.y,
+          ...newItemDimensions,
+        });
+      }
+
       if (dataType === 'frame') {
         await miro.board.createFrame({
           title: formData.get('title') as string,
@@ -53,16 +82,25 @@ export const AddModal = (props: AddModalProps) => {
           },
           width: +(formData.get('width') as string),
           height: +(formData.get('height') as string),
+          x: 0, // for frames we might want to add it relative to the last created frame
+          y: 0,
         });
       }
 
       if (dataType === 'sticky_note') {
+        let fillColor = formData.get('style.fillColor') as StickyNoteColor;
+
+        if (!fillColor && isStickyNote(parent)) {
+          fillColor = parent.style.fillColor as StickyNoteColor;
+        }
+
         newItem = await miro.board.createStickyNote({
           content: formData.get('content') as string,
           style: {
-            fillColor: formData.get('style.fillColor') as StickyNoteColor,
+            fillColor,
           },
         });
+
       }
 
       if (dataType === 'text') {
@@ -71,14 +109,29 @@ export const AddModal = (props: AddModalProps) => {
         });
       }
 
-      const parentId = formData.get('parentId');
-
-      if (parentId && newItem) {
-        const parentFrame = (await miro.board.getById(parentId as string)) as Frame;
-        newItem.x = parentFrame.x + 1;
-        newItem.y = parentFrame.y + 1;
+      if (parent && newItem) {
+        newItem.x = newItemPosition.x;
+        newItem.y = newItemPosition.y;
         await newItem.sync();
-        await parentFrame.add(newItem);
+
+        if (isFrame(parent)) {
+          await parent.add(newItem);
+        } else {
+          const connector = await miro.board.createConnector({
+            shape: 'curved',
+            start: {
+              item: parent.id,
+              position: {
+                x: 1.0, // todo: calculate position relative to parent
+                y: 0.5
+              }
+            },
+            end: {
+              item: newItem.id,
+              snapTo: 'auto'  // todo: calculate type relative to parent
+            }
+          });
+        }
 
         notifyBoardUpdate();
       }

--- a/modals/inputs/InputElement.tsx
+++ b/modals/inputs/InputElement.tsx
@@ -27,6 +27,7 @@ const getReadableFieldName = (fieldName: string): string => {
 
 export const InputElement = (props: InputElementProps): React.ReactElement | null => {
   const { field, parentFrames } = props;
+  const defaultValue = 'defaultValue' in field ? (field.defaultValue as string | undefined) : undefined;
   const currentValue =
     'currentValue' in field ? (field.currentValue as string | undefined) : undefined;
   const [colorEnabled, setColorEnabled] = useState(Boolean(currentValue));
@@ -40,7 +41,7 @@ export const InputElement = (props: InputElementProps): React.ReactElement | nul
         <label className="ally-wb-edit-form-label">
           <span className="ally-wb-edit-form-label-text">{readableFieldName}</span>
           <select name={field.fieldName} id={field.fieldName} required={required}>
-            <ColorOptions currentColor={currentValue ?? ''} />
+            <ColorOptions currentColor={currentValue ?? defaultValue ?? ''} />
           </select>
         </label>
       );

--- a/src/components/hierarchy.tsx
+++ b/src/components/hierarchy.tsx
@@ -65,8 +65,7 @@ export const HierarchyBoard: React.FC<HierarchyBoardProps> = ({ type, label, chi
       <div className="a11ywb-accordion__contents">
         {listItems.length > 0 && (
           <ul>
-            {listItems.length > 0 &&
-              listItems.map((listItem) => <HierarchyListItem key={listItem.id} item={listItem} />)}
+            {listItems.map((listItem) => <HierarchyListItem key={`board-child-${listItem.id}`} item={listItem} />)}
           </ul>
         )}
         {listItems.length === 0 && <p>This board has no items.</p>}
@@ -155,7 +154,7 @@ const TreeBoardItem: React.FC<TreeBoardItemProps> = ({ hierarchyItem, subtype, c
         {listItems.length > 0 && (
           <ul>
             {listItems.length > 0 &&
-              listItems.map((listItem) => <HierarchyListItem key={listItem.id} item={listItem} />)}
+              listItems.map((listItem) => <HierarchyListItem key={`${hierarchyItem.type}-${hierarchyItem.id}-child-${listItem.id}`} item={listItem} />)}
           </ul>
         )}
         {listItems.length === 0 && <p>There are no child items.</p>}
@@ -230,10 +229,55 @@ const TextTypeBoardItem: React.FC<TextTypeBoardItemProps> = ({ hierarchyItem }) 
         Delete Text
       </button>
 
+      <button
+        type="button"
+        onClick={() =>
+          openAddModal({
+            title: 'Add child Sticky Note',
+            stickyNoteFields: [
+              {
+                fieldName: 'content',
+                fieldType: 'rich_text',
+                required: true,
+              },
+              {
+                fieldName: 'style.fillColor',
+                fieldType: 'color_map',
+                defaultValue: hierarchyItem.item.style.fillColor,
+              },
+            ],
+            hierarchyParentId: hierarchyItem.id,
+            hierarchyItem,
+          })
+        }
+      >
+        Add child Sticky Note
+      </button>
+
+      <button
+        type="button"
+        onClick={() =>
+          openAddModal({
+            title: 'Add child Text',
+            textFields: [
+              {
+                fieldName: 'content',
+                fieldType: 'extended_rich_text',
+                required: true,
+              },
+            ],
+            hierarchyParentId: hierarchyItem.id,
+            hierarchyItem,
+          })
+        }
+      >
+        Add child Text
+      </button>
+
       {hierarchyChildren?.length ? (
         <ul>
           {hierarchyChildren.map((child) => (
-            <li key={child.id}>
+            <li key={`${hierarchyItem.type}-${hierarchyItem.id}-child-${child.id}`}>
               <Hierarchy hierarchyItem={child} />
             </li>
           ))}
@@ -337,7 +381,8 @@ const StickyNoteTypeBoardItem: React.FC<StickyNoteTypeBoardItemProps> = ({ hiera
                 defaultValue: hierarchyItem.item.style.fillColor,
               },
             ],
-            parentId: hierarchyItem.id,
+            hierarchyParentId: hierarchyItem.id,
+            hierarchyItem,
           })
         }
       >
@@ -356,7 +401,8 @@ const StickyNoteTypeBoardItem: React.FC<StickyNoteTypeBoardItemProps> = ({ hiera
                 required: true,
               },
             ],
-            parentId: hierarchyItem.id,
+            hierarchyParentId: hierarchyItem.id,
+            hierarchyItem,
           })
         }
       >
@@ -422,7 +468,8 @@ const FrameTypeBoardItem: React.FC<FrameTypeBoardItemProps> = ({ hierarchyItem }
                 fieldType: 'color_map',
               },
             ],
-            parentId: hierarchyItem.id,
+            hierarchyParentId: hierarchyItem.id,
+            hierarchyItem,
           })
         }
       >
@@ -441,7 +488,8 @@ const FrameTypeBoardItem: React.FC<FrameTypeBoardItemProps> = ({ hierarchyItem }
                 required: true,
               },
             ],
-            parentId: hierarchyItem.id,
+            hierarchyParentId: hierarchyItem.id,
+            hierarchyItem,
           })
         }
       >

--- a/src/components/hierarchy.tsx
+++ b/src/components/hierarchy.tsx
@@ -4,7 +4,7 @@ import Tags from './tags';
 import React from 'react';
 import { getItemTypeConfig } from '@utils/items';
 import { getColorConfig } from '@utils/colors';
-import { openConnectModal, openDeleteModal, openEditModal, openMoveModal } from '@utils/open-modal';
+import { openAddModal, openConnectModal, openDeleteModal, openEditModal, openMoveModal } from '@utils/open-modal';
 
 export interface HierarchyProps {
   hierarchyItem: HierarchyItem<Item>;
@@ -319,6 +319,49 @@ const StickyNoteTypeBoardItem: React.FC<StickyNoteTypeBoardItemProps> = ({ hiera
       >
         Delete Sticky Note
       </button>
+
+      <button
+        type="button"
+        onClick={() =>
+          openAddModal({
+            title: 'Add child Sticky Note',
+            stickyNoteFields: [
+              {
+                fieldName: 'content',
+                fieldType: 'rich_text',
+                required: true,
+              },
+              {
+                fieldName: 'style.fillColor',
+                fieldType: 'color_map',
+                defaultValue: hierarchyItem.item.style.fillColor,
+              },
+            ],
+            parentId: hierarchyItem.id,
+          })
+        }
+      >
+        Add child Sticky Note
+      </button>
+
+      <button
+        type="button"
+        onClick={() =>
+          openAddModal({
+            title: 'Add child Text',
+            textFields: [
+              {
+                fieldName: 'content',
+                fieldType: 'extended_rich_text',
+                required: true,
+              },
+            ],
+            parentId: hierarchyItem.id,
+          })
+        }
+      >
+        Add child Text
+      </button>
     </TreeBoardItem>
   );
 };
@@ -362,6 +405,47 @@ const FrameTypeBoardItem: React.FC<FrameTypeBoardItemProps> = ({ hierarchyItem }
         }
       >
         Delete Frame
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          openAddModal({
+            title: 'Add Sticky Note in Frame',
+            stickyNoteFields: [
+              {
+                fieldName: 'content',
+                fieldType: 'rich_text',
+                required: true,
+              },
+              {
+                fieldName: 'style.fillColor',
+                fieldType: 'color_map',
+              },
+            ],
+            parentId: hierarchyItem.id,
+          })
+        }
+      >
+        Add Sticky Note in Frame
+      </button>
+
+      <button
+        type="button"
+        onClick={() =>
+          openAddModal({
+            title: 'Add Text in Frame',
+            textFields: [
+              {
+                fieldName: 'content',
+                fieldType: 'extended_rich_text',
+                required: true,
+              },
+            ],
+            parentId: hierarchyItem.id,
+          })
+        }
+      >
+        Add Text in Frame
       </button>
     </TreeBoardItem>
   );

--- a/src/models/item.ts
+++ b/src/models/item.ts
@@ -45,6 +45,8 @@ export const ItemTypeConfigMap: Record<ItemType, ItemTypeConfig> = {
 
 export type ConnectableItem = StickyNote | Text | Frame;
 
+export type SupportedEndpoint = StickyNote | Text;
+
 export const CONNECTABLE_ITEM_TYPES: ItemType[] = [ItemType.StickyNote, ItemType.Text];
 
 export interface Connection {

--- a/src/models/item.ts
+++ b/src/models/item.ts
@@ -43,11 +43,13 @@ export const ItemTypeConfigMap: Record<ItemType, ItemTypeConfig> = {
   shape: { displayLabel: 'Shape' },
 };
 
-export type ConnectableItem = StickyNote | Text | Frame;
+export type HierarchyItemType = Frame | StickyNote | Text;
 
-export type SupportedEndpoint = StickyNote | Text;
+export type ConnectableItem = StickyNote | Text;
 
 export const CONNECTABLE_ITEM_TYPES: ItemType[] = [ItemType.StickyNote, ItemType.Text];
+
+export const HIERARCHY_ITEM_TYPE: ItemType[] = [ItemType.Frame, ItemType.StickyNote, ItemType.Text];
 
 export interface Connection {
   id: Connector["id"];

--- a/src/models/modals.ts
+++ b/src/models/modals.ts
@@ -1,5 +1,6 @@
 import { Frame, Item, StickyNote, Text } from '@mirohq/websdk-types';
 import { ItemsProps } from '@mirohq/websdk-types/core/builder/types';
+import { ConnectableItem, HierarchyItem } from './item';
 
 type NestedKeyOf<T> = {
   [K in keyof T & string]: NonNullable<T[K]> extends object
@@ -37,7 +38,8 @@ export type AddModalProperties = {
   frameFields?: AddFormField<Frame>[];
   stickyNoteFields?: AddFormField<StickyNote>[];
   textFields?: AddFormField<Text>[];
-  parentId?: string;
+  hierarchyItem?: HierarchyItem;
+  hierarchyParentId?: ConnectableItem['id'];
 };
 
 export type ConnectModalProperties = {
@@ -50,6 +52,7 @@ export type DeleteModalProperties = {
   action: 'delete';
   title: string;
   id: Item['id'];
+  hierarchyParentId?: ConnectableItem['id'];
 };
 
 export type EditModalProperties<T extends Item = Item> = {
@@ -57,12 +60,14 @@ export type EditModalProperties<T extends Item = Item> = {
   title: string;
   item: T;
   fields: EditFormField<T>[];
+  hierarchyParentId?: ConnectableItem['id'];
 };
 
 export type MoveModalProperties = {
   action: 'move';
   title: string;
   item: Item;
+  hierarchyParentId?: ConnectableItem['id'];
 };
 
 export type ModalProperties =

--- a/src/models/modals.ts
+++ b/src/models/modals.ts
@@ -19,10 +19,12 @@ type AddFormField<T extends Frame | StickyNote | Text> = {
     | 'extended_rich_text';
   required?: boolean;
   inputProps?: Record<string, string | number | boolean>;
+  defaultValue?: string | number | boolean;
 };
 
 type EditFormField<T extends Item> = {
   fieldName: NestedKeyOf<ItemsProps<T>>;
+  defaultValue?: string | number | boolean;
   currentValue?: string | number | boolean;
   fieldType: 'text' | 'color' | 'color_map' | 'number' | 'rich_text' | 'extended_rich_text';
   required?: boolean;
@@ -35,6 +37,7 @@ export type AddModalProperties = {
   frameFields?: AddFormField<Frame>[];
   stickyNoteFields?: AddFormField<StickyNote>[];
   textFields?: AddFormField<Text>[];
+  parentId?: string;
 };
 
 export type ConnectModalProperties = {

--- a/src/utils/canvas-geometry.ts
+++ b/src/utils/canvas-geometry.ts
@@ -1,0 +1,98 @@
+import { Frame, Rect } from "@mirohq/websdk-types";
+import { ConnectableItem, SupportedEndpoint } from "@models/item";
+
+export type Position = {
+    x: number;
+    y: number;
+};
+
+export type RelativeBounds = Required<Pick<SupportedEndpoint, 'relativeTo' | 'x'| 'y' | 'width' | 'height'>>;
+
+export interface Bounds {
+    xMin: number;
+    yMin: number;
+    xMax: number;
+    yMax: number;
+}
+
+// Miro sets x,y to origin but we want 4-sided bounds in 2D space
+export function getSpatialBounds(rect: Rect): Bounds {
+    const midWidth = rect.width * 0.5;
+    const midHeight = rect.height * 0.5;
+
+    return {
+        xMin: rect.x - midWidth,
+        yMin: rect.y - midHeight,
+        xMax: rect.x + midWidth,
+        yMax: rect.y + midHeight,
+    };
+}
+
+export function isOverlapping(a: Rect, b: Rect): boolean {
+    const aa = getSpatialBounds(a);
+    const bb = getSpatialBounds(b);
+
+    const padding = 10;
+
+    return aa.xMin < bb.xMax + padding
+        && aa.xMax > bb.xMin - padding
+        && aa.yMin < bb.yMax + padding
+        && aa.yMax > bb.yMin - padding;
+}
+
+export function canBeContainedIn(candidateItem: RelativeBounds, frame: Frame): boolean {
+    // we assume frame.relativeTo is always `canvas_center` so we calculate item position relative to its parent
+    // const itemPosInCanvas = getAbsolutePosition(candidateItem);
+
+    const itemBounds = getSpatialBounds(candidateItem);
+    const frameBounds = getSpatialBounds(frame);
+
+    return itemBounds.xMin >= frameBounds.xMin && itemBounds.xMax <= frameBounds.xMax
+        && itemBounds.yMin >= frameBounds.yMin && itemBounds.yMax <= frameBounds.yMax;
+}
+
+
+export function getAbsolutePosition(item: RelativeBounds, relativeParent?: ConnectableItem): Position {
+    if (item.relativeTo === 'canvas_center') {
+        return {
+            x: item.x,
+            y: item.y,
+        };
+    }
+
+    else if (item.relativeTo === 'parent_top_left' && relativeParent) {
+        const parentAbsolutePosition = getAbsolutePosition(relativeParent);
+
+        // relativeTo parent_top_left is x right, y- up
+        // relativeTo canvas_center is x right, y+ up
+        const parentTopLeft = {
+            x: parentAbsolutePosition.x - (relativeParent.width * 0.5),
+            y: parentAbsolutePosition.y - (relativeParent.height * 0.5),
+        }
+
+        return {
+            x: parentTopLeft.x + item.x,
+            y: parentTopLeft.y + item.y,
+        };
+    }
+
+    else if (item.relativeTo === 'parent_center' && relativeParent) {
+        // todo, have not encountered this yes
+        console.log("relative To PARENT_CENTER", item);
+
+        const parentAbsolutePosition = getAbsolutePosition(relativeParent);
+
+        return {
+            x: parentAbsolutePosition.x + item.x,
+            y: parentAbsolutePosition.y + item.y,
+        };
+    }
+
+    else {
+        // worst case
+        return {
+            x: 0,
+            y: 0,
+        };
+    }
+}

--- a/src/utils/canvas-geometry.ts
+++ b/src/utils/canvas-geometry.ts
@@ -1,12 +1,12 @@
 import { Frame, Rect } from "@mirohq/websdk-types";
-import { ConnectableItem, SupportedEndpoint } from "@models/item";
+import { ConnectableItem, HierarchyItemType } from "@models/item";
 
 export type Position = {
     x: number;
     y: number;
 };
 
-export type RelativeBounds = Required<Pick<SupportedEndpoint, 'relativeTo' | 'x'| 'y' | 'width' | 'height'>>;
+export type RelativeBounds = Required<Pick<ConnectableItem, 'relativeTo' | 'x'| 'y' | 'width' | 'height'>>;
 
 export interface Bounds {
     xMin: number;
@@ -52,7 +52,7 @@ export function canBeContainedIn(candidateItem: RelativeBounds, frame: Frame): b
 }
 
 
-export function getAbsolutePosition(item: RelativeBounds, relativeParent?: ConnectableItem): Position {
+export function getAbsolutePosition(item: RelativeBounds, relativeParent?: HierarchyItemType): Position {
     if (item.relativeTo === 'canvas_center') {
         return {
             x: item.x,

--- a/src/utils/canvas-items.ts
+++ b/src/utils/canvas-items.ts
@@ -1,0 +1,54 @@
+import { Frame, Rect } from "@mirohq/websdk-types";
+import { ConnectableItem } from "@models/item";
+import { getSpatialBounds, Position } from "./canvas-geometry";
+
+export async function expandFrameTowardsItem(frame: Frame, item: Rect) {
+    const frameBounds = getSpatialBounds(frame);
+    const itemBounds = getSpatialBounds(item);
+    const oldY = frame.y;
+    let extraHeight = 0;
+
+    if (itemBounds.xMin > frameBounds.xMax) {
+        const extraWidth = Math.abs(itemBounds.xMax - frameBounds.xMax);
+        frame.width += extraWidth;
+        frame.x += extraWidth * 0.5;
+    }
+    if (itemBounds.xMax < frameBounds.xMin) {
+        const extraWidth = Math.abs(frameBounds.xMin - itemBounds.xMin);
+        frame.width += extraWidth;
+        frame.x -= extraWidth * 0.5;
+    }
+
+    if (itemBounds.yMax > frameBounds.yMax) {
+        extraHeight = Math.abs(itemBounds.yMax - frameBounds.yMax);
+        frame.height += extraHeight;
+        frame.y += extraHeight * 0.5;
+        
+    }
+    if (itemBounds.yMin < frameBounds.yMin) {
+        extraHeight = Math.abs(frameBounds.yMin - itemBounds.yMin);
+        frame.height += extraHeight;
+        frame.y -= extraHeight * 0.5;
+    }
+
+    console.log('frameBounds.yMin', frameBounds.yMin);
+    console.log('frameBounds.yMax', frameBounds.yMax);
+    console.log('itemBounds.yMin', itemBounds.yMin);
+    console.log('itemBounds.yMax', itemBounds.yMax);
+    console.log('extraHeight', extraHeight);
+    console.log('frame.y before/after', oldY, frame.y);
+
+    
+
+    await frame.sync();
+}
+
+export function getSnapOffset(position: Position, item: ConnectableItem, snapTo?: string): Position {
+    switch (snapTo) {
+        case 'top':    return { x: position.x, y: position.y - item.height * 0.5 };
+        case 'bottom': return { x: position.x, y: position.y + item.height * 0.5 };
+        case 'left':   return { x: position.x - item.width * 0.5, y: position.y };
+        case 'right':  return { x: position.x + item.width * 0.5, y: position.y };
+        default:       return position; // auto: todo: should calculate based on direction relative to counterpart
+    }
+}

--- a/src/utils/forms.ts
+++ b/src/utils/forms.ts
@@ -1,5 +1,5 @@
 
-export function parseFloatFromForm(formData: FormDataEntryValue | null): number | null {
+export function parseFloatFromForm(formData: FormDataEntryValue | null): number | undefined {
     if (typeof formData === 'string') {
         const parsed = parseFloat(formData);
 
@@ -8,5 +8,5 @@ export function parseFloatFromForm(formData: FormDataEntryValue | null): number 
         }
     }
 
-    return null;
+    return undefined;
 }

--- a/src/utils/forms.ts
+++ b/src/utils/forms.ts
@@ -1,0 +1,12 @@
+
+export function parseFloatFromForm(formData: FormDataEntryValue | null): number | null {
+    if (typeof formData === 'string') {
+        const parsed = parseFloat(formData);
+
+        if (!isNaN(parsed)) {
+            return parsed;
+        }
+    }
+
+    return null;
+}

--- a/src/utils/hierarchy-builder.ts
+++ b/src/utils/hierarchy-builder.ts
@@ -1,6 +1,6 @@
 import type { Item, Frame, StickyNote } from '@mirohq/websdk-types';
-import { ConnectionRecord, getLabel, isConnectableItem } from '@utils/items';
-import { ConnectableItem, HierarchyItemMetadata, ItemType, type HierarchyItem } from '@models/item';
+import { ConnectionRecord, getLabel, isConnectableItem, isFrame } from '@utils/items';
+import { ConnectableItem, HierarchyItemMetadata, HierarchyItemType, ItemType, type HierarchyItem } from '@models/item';
 import { ItemRecord, TagRecord } from '@models/record';
 import { getTags } from './tags';
 import { buildConnectionRecord, buildItemRecord, buildTagRecord } from './record-builder';
@@ -88,12 +88,12 @@ function buildConnectorChild(
       tagRecord: TagRecord,
     },
     visited = new Set<StickyNote['id']>(), 
-): HierarchyItem<ConnectableItem> {
+): HierarchyItem<HierarchyItemType> {
     const { level, connectionRecord, itemRecord, tagRecord } = buildOptions;
 
     visited.add(item.id);
 
-    const children: HierarchyItem<ConnectableItem>[] = [];
+    const children: HierarchyItem<HierarchyItemType>[] = [];
 
     (item.connectorIds ?? []).forEach(connectorId => {
       const connector = connectionRecord[connectorId];
@@ -103,11 +103,13 @@ function buildConnectorChild(
 
       if (endId && !visited.has(endId)) {
         const childItem = itemRecord[endId];
+
         if (isConnectableItem(childItem)) {
-          children.push(buildConnectorChild(childItem, {
+          const connectorChild = buildConnectorChild(childItem, {
             ...buildOptions,
             level: childLevel
-          }))
+          });
+          children.push(connectorChild);
         }
       }
     });
@@ -119,7 +121,7 @@ function buildConnectorChild(
     return hierarchyItem;
   }
 
-export function buildConnectorHierarchy(items: Item[]): HierarchyItem<ConnectableItem>[] {
+export function buildConnectorHierarchy(items: Item[]): HierarchyItem<HierarchyItemType>[] {
   const itemRecord = buildItemRecord(items);
   const connectionRecord = buildConnectionRecord(itemRecord);
   const tagRecord = buildTagRecord(items);
@@ -141,17 +143,17 @@ export function buildConnectorHierarchy(items: Item[]): HierarchyItem<Connectabl
 
   return items
     .filter(item => {
-      if (item.type === ItemType.Frame) {
+      if (isFrame(item)) {
         return true;
       }
 
-      if ([ItemType.StickyNote, ItemType.Text].includes(item.type as ItemType)) {
+      if (isConnectableItem(item)) {
         return !('parentId' in item && item.parentId)
       }
       return false;
     })
     .map(item => {
-      if (item.type !== ItemType.Frame) {
+      if (!isFrame(item)) {
         return hierarchyRecord[item.id];
       }
 
@@ -160,11 +162,15 @@ export function buildConnectorHierarchy(items: Item[]): HierarchyItem<Connectabl
         .map(child => hierarchyRecord[child.id])
         .filter(Boolean);
 
-      const hierarchyItem = buildHierarchyItem<Frame>(item as Frame, children, {
-        level: 0,
-        tagRecord,
-        connectionRecord,
-      });
+      const hierarchyItem = buildHierarchyItem<Frame>(
+        item as Frame, 
+        children, 
+        {
+          level: 0,
+          tagRecord,
+          connectionRecord,
+        }
+      );
 
       return hierarchyItem;
     });

--- a/src/utils/hierarchy-builder.ts
+++ b/src/utils/hierarchy-builder.ts
@@ -1,9 +1,9 @@
 import type { Item, Frame, StickyNote } from '@mirohq/websdk-types';
 import { ConnectionRecord, getLabel, isConnectableItem } from '@utils/items';
 import { ConnectableItem, HierarchyItemMetadata, ItemType, type HierarchyItem } from '@models/item';
-import { ConnectorRecord, ItemRecord, TagRecord } from '@models/record';
+import { ItemRecord, TagRecord } from '@models/record';
 import { getTags } from './tags';
-import { buildConnectorRecord, buildItemRecord, buildTagRecord } from './record-builder';
+import { buildConnectionRecord, buildItemRecord, buildTagRecord } from './record-builder';
 
 function computeHierarchyItemMetadata(children: HierarchyItem[]): HierarchyItemMetadata {
   const treeChildCount = children.length + children.reduce((acc, child) => {
@@ -28,9 +28,13 @@ export function buildHierarchyItem<T extends Item>(
   buildOptions: {
     level: number,
     tagRecord: TagRecord,
+    connectionRecord: ConnectionRecord,
   }
 ): HierarchyItem<T> {
-  const { level, tagRecord } = buildOptions;
+  const { level, tagRecord, connectionRecord } = buildOptions;
+
+  const connections = Object.values(connectionRecord)
+    .filter(connection => connection?.id === item.id ||connection.endItem?.id === item.id);
 
   return {
     id: item.id,
@@ -41,6 +45,7 @@ export function buildHierarchyItem<T extends Item>(
     tags: getTags(item, tagRecord),
     children,
     metadata: computeHierarchyItemMetadata(children),
+    connections,
   };
 }
 
@@ -53,7 +58,7 @@ export function buildHierarchy(
     connectionRecord: ConnectionRecord;
   }
 ): HierarchyItem<Item> {
-  const { level, tagRecord, itemRecord } = builderOptions;
+  const { level, tagRecord, itemRecord, connectionRecord } = builderOptions;
 
   let children: HierarchyItem[] = [];
   if (item.type === ItemType.Frame) {
@@ -69,7 +74,7 @@ export function buildHierarchy(
     );
   }
 
-  const hierarchyItem = buildHierarchyItem(item, children, { level, tagRecord });
+  const hierarchyItem = buildHierarchyItem(item, children, { level, tagRecord, connectionRecord });
   
   return hierarchyItem;
 }
@@ -78,21 +83,21 @@ function buildConnectorChild(
     item: ConnectableItem, 
     buildOptions: {
       level: number,
-      connectorRecord: ConnectorRecord, 
+      connectionRecord: ConnectionRecord, 
       itemRecord: ItemRecord,
       tagRecord: TagRecord,
     },
     visited = new Set<StickyNote['id']>(), 
 ): HierarchyItem<ConnectableItem> {
-    const { level, connectorRecord, itemRecord, tagRecord } = buildOptions;
+    const { level, connectionRecord, itemRecord, tagRecord } = buildOptions;
 
     visited.add(item.id);
 
     const children: HierarchyItem<ConnectableItem>[] = [];
 
     (item.connectorIds ?? []).forEach(connectorId => {
-      const connector = connectorRecord[connectorId];
-      const endId = connector?.end?.item;
+      const connector = connectionRecord[connectorId];
+      const endId = connector?.endItem?.id;
 
       const childLevel = level + 1;
 
@@ -108,22 +113,22 @@ function buildConnectorChild(
     });
 
     const hierarchyItem = buildHierarchyItem(item, children, { 
-      level, tagRecord
+      level, tagRecord, connectionRecord
     });
 
     return hierarchyItem;
   }
 
 export function buildConnectorHierarchy(items: Item[]): HierarchyItem<ConnectableItem>[] {
-  const connectorRecord = buildConnectorRecord(items);
   const itemRecord = buildItemRecord(items);
+  const connectionRecord = buildConnectionRecord(itemRecord);
   const tagRecord = buildTagRecord(items);
-  const buildOptions = { level: 0, connectorRecord, itemRecord, tagRecord };
+  const buildOptions = { level: 0, connectionRecord, itemRecord, tagRecord };
 
   const hasIncomingConnector = new Set<Item['id']>();
-  Object.values(connectorRecord).forEach(connector => {
-    if (connector.end?.item) {
-      hasIncomingConnector.add(connector.end.item);
+  Object.values(connectionRecord).forEach(connector => {
+    if (connector.endItem) {
+      hasIncomingConnector.add(connector.endItem?.id);
     }
   });
   
@@ -158,6 +163,7 @@ export function buildConnectorHierarchy(items: Item[]): HierarchyItem<Connectabl
       const hierarchyItem = buildHierarchyItem<Frame>(item as Frame, children, {
         level: 0,
         tagRecord,
+        connectionRecord,
       });
 
       return hierarchyItem;

--- a/src/utils/item-placer.ts
+++ b/src/utils/item-placer.ts
@@ -1,0 +1,30 @@
+
+export interface ItemPlacementOptions {
+    x?: number | null;
+    y?: number | null;
+    height?: number | null;
+    width?: number | null;
+}
+
+export async function findItemPlacement(options?: ItemPlacementOptions): Promise<{ x: number; y: number }> {
+    const x = options?.x ?? 0;
+    const y = options?.y ?? 0;
+    const height = options?.height ?? 200; // todo: move to config
+    const width = options?.width ?? 200;
+
+    // simplest case: fallback to Miro's computation
+    const candidateEmptySpace = await miro.board.findEmptySpace({
+        x,
+        y,
+        height,
+        width,
+    });
+
+    // next case is we want to place it relative to its siblings in that it spreads out
+    // like a fan from their parent
+
+    return {
+        x: candidateEmptySpace.x,
+        y: candidateEmptySpace.y,
+    };
+};

--- a/src/utils/item-placer.ts
+++ b/src/utils/item-placer.ts
@@ -1,7 +1,7 @@
 import { Connector, Frame, Rect } from "@mirohq/websdk-types";
 import { Endpoint } from "@mirohq/websdk-types/core/features/widgets/connector";
-import { ConnectableItem, HierarchyItem } from "@models/item";
-import { isConnectableItem, isConnector, isFrame, isSupportedEndpoint } from "./items";
+import { ConnectableItem, HierarchyItem, HierarchyItemType } from "@models/item";
+import { isConnectableItem, isConnector, isFrame, isHierarchyItem } from "./items";
 import { canBeContainedIn, getAbsolutePosition, getSpatialBounds, Position, RelativeBounds } from "./canvas-geometry";
 import { spiralSearch } from "./placement-strategy";
 import { expandFrameTowardsItem, getSnapOffset } from "./canvas-items";
@@ -19,7 +19,7 @@ export interface ItemPlacementOptions {
 export async function placeItem(item: ConnectableItem, options: ItemPlacementOptions = {}): Promise<void> {
     const { parent } = options;
 
-    if (isConnectableItem(parent?.item)) {
+    if (isHierarchyItem(parent?.item)) {
         let frame: Frame | undefined = undefined;
 
         let frameId = isFrame(parent.item) ? parent.id : parent.item.parentId;
@@ -30,11 +30,11 @@ export async function placeItem(item: ConnectableItem, options: ItemPlacementOpt
             const futurePlacement = await findFuturePlacement(item, { 
                 width: item.width, 
                 height: item.height,
-                parent: parent,
+                parent,
                 frame,
             });
 
-            if (futurePlacement && isSupportedEndpoint(item)) {
+            if (futurePlacement && isConnectableItem(item)) {
                 const parentAbsolutePos = getAbsolutePosition(parent.item, frame);
                 const parentRect = {
                     x: parentAbsolutePos.x,
@@ -42,19 +42,23 @@ export async function placeItem(item: ConnectableItem, options: ItemPlacementOpt
                     height: parent.item.height,
                     width: parent.item.width,
                 };
-                const connectorEndpoints = calculateConnectorEndpoints(parentRect, futurePlacement);
 
-                await miro.board.createConnector({
-                    shape: 'curved',
-                    start: {
-                        item: parent.item.id,
-                        snapTo: connectorEndpoints.start.snapTo,
-                    },
-                    end: {
-                        item: parent.id,
-                        snapTo: connectorEndpoints.end.snapTo,
-                    }
-                });
+                if (parent.id !== frameId) {
+                    // only add connectors if parent is not a frame
+                    const connectorEndpoints = calculateConnectorEndpoints(parentRect, futurePlacement);
+
+                    await miro.board.createConnector({
+                        shape: 'curved',
+                        start: {
+                            item: parent.item.id,
+                            snapTo: connectorEndpoints.start.snapTo,
+                        },
+                        end: {
+                            item: item.id,
+                            snapTo: connectorEndpoints.end.snapTo,
+                        }
+                    });
+                }
 
                 item.x = futurePlacement.x;
                 item.y = futurePlacement.y;
@@ -92,7 +96,7 @@ export async function findFuturePlacement(item: ConnectableItem, options?: ItemP
         const frameChildren = await frame.getChildren();
 
         const existingItems = frameChildren
-            .filter(child => isSupportedEndpoint(child) || isConnector(child))
+            .filter(child => isConnectableItem(child) || isConnector(child))
             .map(child => {
                 // fallback to frame center to fail gracefully
                 let absolutePosition = {
@@ -104,7 +108,7 @@ export async function findFuturePlacement(item: ConnectableItem, options?: ItemP
                     const startItem = frameChildren.find(frameChild => frameChild.id === child.start?.item);
                     const endItem = frameChildren.find(frameChild => frameChild.id === child.end?.item);
 
-                    if (isSupportedEndpoint(startItem) && isSupportedEndpoint(endItem)) {
+                    if (isConnectableItem(startItem) && isConnectableItem(endItem)) {
                         absolutePosition = getConnectorPosition(child, startItem, endItem, frame); 
                     }
                 } else {
@@ -121,7 +125,7 @@ export async function findFuturePlacement(item: ConnectableItem, options?: ItemP
 
         let spiralOrigin: RelativeBounds = frame;
 
-        if (isConnectableItem(options?.parent?.item)) {
+        if (isHierarchyItem(options?.parent?.item)) {
             const parentPos = getAbsolutePosition(options.parent.item, frame);
             spiralOrigin = {
                 relativeTo: 'canvas_center',
@@ -169,7 +173,7 @@ export async function findFramePlacement(options?: ItemPlacementOptions): Promis
 };
 
 // return position based on connector's origin
-export function getConnectorPosition(connector: Connector, startItem: ConnectableItem, endItem: ConnectableItem, relativeParent?: ConnectableItem): Position {
+export function getConnectorPosition(connector: Connector, startItem: ConnectableItem, endItem: ConnectableItem, relativeParent?: HierarchyItemType): Position {
     const startAbsPos = getAbsolutePosition(startItem, relativeParent);
     const endAbsPos = getAbsolutePosition(endItem, relativeParent);
 

--- a/src/utils/item-placer.ts
+++ b/src/utils/item-placer.ts
@@ -1,12 +1,154 @@
+import { Connector, Frame, Rect } from "@mirohq/websdk-types";
+import { Endpoint } from "@mirohq/websdk-types/core/features/widgets/connector";
+import { ConnectableItem, HierarchyItem } from "@models/item";
+import { isConnectableItem, isConnector, isFrame, isSupportedEndpoint } from "./items";
+import { canBeContainedIn, getAbsolutePosition, getSpatialBounds, Position, RelativeBounds } from "./canvas-geometry";
+import { spiralSearch } from "./placement-strategy";
+import { expandFrameTowardsItem, getSnapOffset } from "./canvas-items";
 
 export interface ItemPlacementOptions {
     x?: number | null;
     y?: number | null;
     height?: number | null;
     width?: number | null;
+    parent?: HierarchyItem | null;
+    frame?: Frame;
+    siblings?: HierarchyItem[];
 }
 
-export async function findItemPlacement(options?: ItemPlacementOptions): Promise<{ x: number; y: number }> {
+export async function placeItem(item: ConnectableItem, options: ItemPlacementOptions = {}): Promise<void> {
+    const { parent } = options;
+
+    if (isConnectableItem(parent?.item)) {
+        let frame: Frame | undefined = undefined;
+
+        let frameId = isFrame(parent.item) ? parent.id : parent.item.parentId;
+
+        if (frameId) {
+            frame = await miro.board.getById(frameId) as Frame;
+
+            const futurePlacement = await findFuturePlacement(item, { 
+                width: item.width, 
+                height: item.height,
+                parent: parent,
+                frame,
+            });
+
+            if (futurePlacement && isSupportedEndpoint(item)) {
+                const parentAbsolutePos = getAbsolutePosition(parent.item, frame);
+                const parentRect = {
+                    x: parentAbsolutePos.x,
+                    y: parentAbsolutePos.y,
+                    height: parent.item.height,
+                    width: parent.item.width,
+                };
+                const connectorEndpoints = calculateConnectorEndpoints(parentRect, futurePlacement);
+
+                await miro.board.createConnector({
+                    shape: 'curved',
+                    start: {
+                        item: parent.item.id,
+                        snapTo: connectorEndpoints.start.snapTo,
+                    },
+                    end: {
+                        item: parent.id,
+                        snapTo: connectorEndpoints.end.snapTo,
+                    }
+                });
+
+                item.x = futurePlacement.x;
+                item.y = futurePlacement.y;
+
+                await item.sync();
+                await frame.add(item);
+            } else {
+                // cannot add to frame, but we rearrange so it does not overlap other failed attempts
+
+                const emptySpot = await findFramePlacement(item);
+                item.x = emptySpot.x;
+                item.y = emptySpot.y;
+                await item.sync();
+            }
+        }
+    }
+}
+
+export async function findFuturePlacement(item: ConnectableItem, options?: ItemPlacementOptions): Promise<RelativeBounds | null> {
+    const { parent, frame } = options ?? {};
+
+    // base case, delegate to Miro's auto-placement
+    if (!frame && !parent) {
+        const autoPosition = await miro.board.findEmptySpace(item);
+        
+        item.x = autoPosition.x;
+        item.y = autoPosition.y;
+        item.sync();
+
+        return item;
+    }
+
+    // case 2: frame parent, no connectors
+    if (frame) {
+        const frameChildren = await frame.getChildren();
+
+        const existingItems = frameChildren
+            .filter(child => isSupportedEndpoint(child) || isConnector(child))
+            .map(child => {
+                // fallback to frame center to fail gracefully
+                let absolutePosition = {
+                    x: frame.x,
+                    y: frame.y,
+                };
+                
+                if (isConnector(child)) {
+                    const startItem = frameChildren.find(frameChild => frameChild.id === child.start?.item);
+                    const endItem = frameChildren.find(frameChild => frameChild.id === child.end?.item);
+
+                    if (isSupportedEndpoint(startItem) && isSupportedEndpoint(endItem)) {
+                        absolutePosition = getConnectorPosition(child, startItem, endItem, frame); 
+                    }
+                } else {
+                    absolutePosition = getAbsolutePosition(child, frame);
+                }
+
+                return {
+                    x: absolutePosition.x,
+                    y: absolutePosition.y,
+                    width: child.width,
+                    height: child.height,  
+                };
+            });
+
+        let spiralOrigin: RelativeBounds = frame;
+
+        if (isConnectableItem(options?.parent?.item)) {
+            const parentPos = getAbsolutePosition(options.parent.item, frame);
+            spiralOrigin = {
+                relativeTo: 'canvas_center',
+                x: parentPos.x,
+                y: parentPos.y,
+                width: options.parent.item.width,
+                height: options.parent.item.height,
+            }
+        }
+
+        const attemptBounds = spiralSearch(item, existingItems, spiralOrigin);
+
+        if (attemptBounds) {
+            if (canBeContainedIn(attemptBounds, frame)) {
+                return attemptBounds;
+            }
+
+            // resize frame after several failed attempts
+            await expandFrameTowardsItem(frame, attemptBounds);
+            return attemptBounds;
+        }
+    }
+
+    return null;
+};
+
+export async function findFramePlacement(options?: ItemPlacementOptions): Promise<{ x: number; y: number }> {
     const x = options?.x ?? 0;
     const y = options?.y ?? 0;
     const height = options?.height ?? 200; // todo: move to config
@@ -20,11 +162,57 @@ export async function findItemPlacement(options?: ItemPlacementOptions): Promise
         width,
     });
 
-    // next case is we want to place it relative to its siblings in that it spreads out
-    // like a fan from their parent
-
     return {
         x: candidateEmptySpace.x,
         y: candidateEmptySpace.y,
     };
 };
+
+// return position based on connector's origin
+export function getConnectorPosition(connector: Connector, startItem: ConnectableItem, endItem: ConnectableItem, relativeParent?: ConnectableItem): Position {
+    const startAbsPos = getAbsolutePosition(startItem, relativeParent);
+    const endAbsPos = getAbsolutePosition(endItem, relativeParent);
+
+    const connectorStartPos = getSnapOffset(startAbsPos, startItem, connector.start?.snapTo);
+    const connectorEndPos = getSnapOffset(endAbsPos, endItem, connector.end?.snapTo);
+
+    return {
+        x: (connectorStartPos.x + connectorEndPos.x) * 0.5,
+        y: (connectorStartPos.y + connectorEndPos.y) * 0.5,
+    };
+}
+
+
+// Assume all positions are absolute
+export function calculateConnectorEndpoints(startItem: Rect, endItem: Rect): { start: Endpoint; end: Endpoint } {
+    const endpoints: { start: Endpoint; end: Endpoint } = {
+        start: {
+            snapTo: 'auto',
+        },
+        end: {
+            snapTo: 'auto'
+        }
+    };
+
+    const startBounds = getSpatialBounds(startItem);
+    const endBounds = getSpatialBounds(endItem);
+
+    // bias towards x-hemispheres
+    if (endBounds.xMin > startBounds.xMax) {
+        endpoints.start.snapTo = 'right';
+        endpoints.end.snapTo = 'left';
+    } else if (endBounds.xMax < startBounds.xMin) {
+        endpoints.start.snapTo = 'left';
+        endpoints.end.snapTo = 'right';
+    } else { // both start and end items are vertical aligned
+        if (endBounds.yMin > startBounds.yMax) {
+            endpoints.start.snapTo = 'bottom';
+            endpoints.end.snapTo = 'top';
+        } else if (endBounds.yMax < startBounds.yMin) {
+            endpoints.start.snapTo = 'top';
+            endpoints.end.snapTo = 'bottom';
+        } // else: overlap, fallback to auto
+    }
+
+    return endpoints;
+}

--- a/src/utils/items.ts
+++ b/src/utils/items.ts
@@ -1,5 +1,5 @@
 import { Connector, Frame, Item, StickyNote, Tag, Text } from '@mirohq/websdk-types';
-import { CONNECTABLE_ITEM_TYPES, ConnectableItem, SupportedEndpoint, Connection, ItemType, ItemTypeConfig, ItemTypeConfigMap } from '@models/item';
+import { CONNECTABLE_ITEM_TYPES, Connection, ItemType, ItemTypeConfig, ItemTypeConfigMap, HIERARCHY_ITEM_TYPE, HierarchyItemType, ConnectableItem } from '@models/item';
 
 export function getLabel(item?: Item): string {
   let label: string | undefined = undefined;
@@ -27,12 +27,12 @@ export function getLabel(item?: Item): string {
 
 export type ConnectionRecord = Record<Connector["id"], Connection>;
 
-export function isConnectableItem(item?: Item): item is ConnectableItem {
-  return CONNECTABLE_ITEM_TYPES.includes(item?.type as ItemType);
+export function isHierarchyItem(item?: Item): item is HierarchyItemType {
+  return HIERARCHY_ITEM_TYPE.includes(item?.type as ItemType);
 }
 
-export function isSupportedEndpoint(item?: Item): item is SupportedEndpoint {
-  return isStickyNote(item) || isText(item);
+export function isConnectableItem(item?: Item): item is ConnectableItem {
+  return CONNECTABLE_ITEM_TYPES.includes(item?.type as ItemType);
 }
 
 export function getItemTypeConfig(itemType: ItemType): ItemTypeConfig | undefined {

--- a/src/utils/items.ts
+++ b/src/utils/items.ts
@@ -37,22 +37,22 @@ export function getItemTypeConfig(itemType: ItemType): ItemTypeConfig | undefine
   return config ?? itemType;
 }
 
-export function isStickyNote(item: Item): item is StickyNote {
-  return item.type === ItemType.StickyNote;
+export function isStickyNote(item?: Item | null): item is StickyNote {
+  return item?.type === ItemType.StickyNote;
 }
 
-export function isFrame(item: Item): item is Frame {
-  return item.type === ItemType.Frame;
+export function isFrame(item?: Item | null): item is Frame {
+  return item?.type === ItemType.Frame;
 }
 
-export function isText(item: Item): item is Text {
-  return item.type === ItemType.Frame;
+export function isText(item?: Item | null): item is Text {
+  return item?.type === ItemType.Text;
 }
 
-export function isConnector(item: Item): item is Connector {
-  return item.type === ItemType.Connector;
+export function isTag(item?: Item | null): item is Tag {
+  return item?.type === ItemType.Tag;
 }
 
-export function isTag(item: Item): item is Tag {
-  return item.type === ItemType.Tag;
+export function isConnector(item?: Item | null): item is Connector {
+  return item?.type === ItemType.Connector;
 }

--- a/src/utils/items.ts
+++ b/src/utils/items.ts
@@ -1,5 +1,5 @@
 import { Connector, Frame, Item, StickyNote, Tag, Text } from '@mirohq/websdk-types';
-import { CONNECTABLE_ITEM_TYPES, ConnectableItem, Connection, ItemType, ItemTypeConfig, ItemTypeConfigMap } from '@models/item';
+import { CONNECTABLE_ITEM_TYPES, ConnectableItem, SupportedEndpoint, Connection, ItemType, ItemTypeConfig, ItemTypeConfigMap } from '@models/item';
 
 export function getLabel(item?: Item): string {
   let label: string | undefined = undefined;
@@ -27,8 +27,12 @@ export function getLabel(item?: Item): string {
 
 export type ConnectionRecord = Record<Connector["id"], Connection>;
 
-export function isConnectableItem(item: Item): item is ConnectableItem {
-  return CONNECTABLE_ITEM_TYPES.includes(item.type as ItemType);
+export function isConnectableItem(item?: Item): item is ConnectableItem {
+  return CONNECTABLE_ITEM_TYPES.includes(item?.type as ItemType);
+}
+
+export function isSupportedEndpoint(item?: Item): item is SupportedEndpoint {
+  return isStickyNote(item) || isText(item);
 }
 
 export function getItemTypeConfig(itemType: ItemType): ItemTypeConfig | undefined {

--- a/src/utils/placement-strategy.ts
+++ b/src/utils/placement-strategy.ts
@@ -1,0 +1,84 @@
+import { Rect } from "@mirohq/websdk-types";
+import { isOverlapping, RelativeBounds } from "./canvas-geometry";
+
+export interface SpiralSearchOptions {
+    startingRingSize?: number;
+    ringMargin?: number;
+    maxRingCount?: number;
+}
+
+export const SPIRAL_SEARCH_DEFAULT_OPTIONS: Required<SpiralSearchOptions> = {
+    startingRingSize: 20,
+    ringMargin: 20,
+    maxRingCount: 10
+}
+
+// assumed all item positions are absolute
+export function spiralSearch(item: Rect, existingItems: Rect[], origin: RelativeBounds, options?: SpiralSearchOptions): RelativeBounds | null {
+    if (!existingItems?.length) {
+        return origin;
+    }
+
+    const startingRingSize = options?.startingRingSize ?? SPIRAL_SEARCH_DEFAULT_OPTIONS.startingRingSize;
+    const ringMargin = options?.ringMargin ?? SPIRAL_SEARCH_DEFAULT_OPTIONS.ringMargin;
+    const maxRingCount = options?.maxRingCount ?? SPIRAL_SEARCH_DEFAULT_OPTIONS.maxRingCount;
+
+    const ringWidth = Math.max(item.width, item.height) + ringMargin;
+
+    let lastAttempt: RelativeBounds | null = null;
+    for (let ringIndex = 0; ringIndex < maxRingCount; ringIndex++) {
+        const radiusOffset = startingRingSize;
+        const ringSliceCount = (ringIndex + 1) * 4 + 4;
+        const radius = radiusOffset + ringWidth * (ringIndex + 1) * 1.5; // radius from origin
+
+        // NOTE: leaving this commented for now, not sure if we want this optimization
+        // const minAngularOffset = Math.atan2(
+        //     Math.max(item.width, item.height),
+        //     radius,
+        // ); // leave space for arrows to pass through
+
+        for (let sliceIndex = 0; sliceIndex < ringSliceCount; sliceIndex++) {
+            // avoid making a grid-like alignment
+            const sliceAngle = (2 * Math.PI) / ringSliceCount;
+            const ringOffset = ((ringIndex + 1) % 2) * sliceAngle * 0.5;
+            const angle = ringOffset + ((Math.PI / 2) - (sliceIndex / ringSliceCount) * 2 * Math.PI);
+
+            // NOTE: leaving this commented for now, not sure if we want this optimization
+            //
+            // since board items can be placed manually by sighted users, we have no control
+            // over whether the next ideal placement lands neatly within the slice
+            // so we do an additional check to ensure enough space for arrows to pass through
+            // const isBelowOffset = existingItems.some(existingItem => {
+            //     const existingAngle = Math.atan2(existingItem.y - origin.y, existingItem.x - origin.x);
+            //     const angleDifference = Math.abs(angle - existingAngle);
+            //     const wraparound = Math.min(angleDifference, 2 * Math.PI - angleDifference);
+
+            //     return wraparound < minAngularOffset;
+            // });
+
+            // if (isBelowOffset) {
+                // skip to next slice
+                // continue;
+            // }
+
+            const candidate: RelativeBounds = {
+                relativeTo: 'canvas_center',
+                x: origin.x + radius * Math.cos(angle),
+                y: origin.y + radius * Math.sin(angle),
+                width: item.width,
+                height: item.height,
+            };
+
+            lastAttempt = candidate;
+
+            const isFreeSpace = existingItems.every(existingItem => !isOverlapping(existingItem, candidate));
+
+            if (isFreeSpace) {
+                return lastAttempt;
+            }
+        }
+    }
+
+    // giving up
+    return lastAttempt;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,11 +24,12 @@
       "@config/*": ["./src/config/*"],
       "@models/*": ["./src/models/*"],
       "@utils/*": ["./src/utils/*"],
-      "@data/*": ["./data/*"]
+      "@data/*": ["./data/*"],
     }
   },
   "include": [
     "src",
+    "modals",
     "pages",
     "*.ts"
 , "modals/edit-dialog.js"  ],


### PR DESCRIPTION
# Overview
<img width="719" height="636" alt="image" src="https://github.com/user-attachments/assets/9d30aaea-3524-4dc1-8925-1dbf0fbeb962" />

Introduced item placement algorithm to avoid overlapping and to auto-position them relative to parent nodes.

We want to simulate Mind Maps so trees fan out from the center.

# Changes
- Allow creating child Sticky Notes and Texts within the hierarchy
- Find placement of new items in a way that matches the visual hierarchy, i.e:
  - incrementally follow an anti-clockwise order starting from top-down, left-right order
  - notion of rings: fill up a ring before moving to the ring farther away from the parent node
- Handle overlapping elements when creating:
  - within a frame: find any available space, if none, expand frame to accommodate frame
  - as a child of a sticky note or text: automatically create connection and position

# Fixes: 
#27