### PR TITLE
Colors: Fix tag and sticky note color codes to match Miro's

### DIFF
--- a/src/styles/components/sticky-note.css
+++ b/src/styles/components/sticky-note.css
@@ -1,22 +1,20 @@
 :root {
-    /* Sticky note color palette - some colors are shared with tags
-    so we may want to define a more global color palette */
-    --sticky-note-color-red: #ff5c5c;
-    --sticky-note-color-pink: #b9398e;
-    --sticky-note-color-light_pink: #ee9ed3;
-    --sticky-note-color-blue: #1f4ecf;
-    --sticky-note-color-light_blue: #9bd5ff;
-    --sticky-note-color-dark_blue: #00316e;
-    --sticky-note-color-cyan: #1dd0e8;
-    --sticky-note-color-green: #16ba3a;
-    --sticky-note-color-light_green: #74ff8d;
-    --sticky-note-color-dark_green: #004b02;
-    --sticky-note-color-yellow: #e6d329;
-    --sticky-note-color-light_yellow: #fbff80;
-    --sticky-note-color-orange: #d6951d;
-    --sticky-note-color-violet: #3410a2;
-    --sticky-note-color-gray: #a9a9a9;
-    --sticky-note-color-black: #0d0d0d;
+    --sticky-note-color-gray: rgb(243, 245, 247);
+    --sticky-note-color-light_yellow: rgb(255, 247, 158);
+    --sticky-note-color-yellow: rgb(255, 232, 109);
+    --sticky-note-color-orange: rgb(255, 181, 117);
+    --sticky-note-color-light_green: rgb(209, 240, 159);
+    --sticky-note-color-green: rgb(179, 230, 95);
+    --sticky-note-color-dark_green: rgb(106, 224, 141);
+    --sticky-note-color-cyan: rgb(129, 231, 222);
+    --sticky-note-color-light_pink: rgb(255, 210, 242);
+    --sticky-note-color-pink: rgb(253, 154, 231);
+    --sticky-note-color-violet: rgb(184, 172, 251);
+    --sticky-note-color-red: rgb(255, 158, 158);
+    --sticky-note-color-light_blue: rgb(178, 208, 254);
+    --sticky-note-color-blue: rgb(156, 230, 255);
+    --sticky-note-color-dark_blue: rgb(134, 180, 249);
+    --sticky-note-color-black: rgb(21, 21, 21);
 }
 
 .a11ywb-board-item__metadata-color {
@@ -31,7 +29,7 @@
 
     &[data-color="pink"] {
         background-color: var(--sticky-note-color-pink);
-        color: white;
+        color: black;
     }
 
     &[data-color="light_pink"] {
@@ -41,7 +39,7 @@
 
     &[data-color="blue"] {
         background-color: var(--sticky-note-color-blue);
-        color: white;
+        color: black;
     }
 
     &[data-color="light_blue"] {
@@ -51,7 +49,7 @@
 
     &[data-color="dark_blue"] {
         background-color: var(--sticky-note-color-dark_blue);
-        color: white;
+        color: black;
     }
 
     &[data-color="cyan"] {
@@ -71,7 +69,7 @@
 
     &[data-color="dark_green"] {
         background-color: var(--sticky-note-color-dark_green);
-        color: white;
+        color: black;
     }
 
     &[data-color="yellow"] {
@@ -91,7 +89,7 @@
 
     &[data-color="violet"] {
         background-color: var(--sticky-note-color-violet);
-        color: white;
+        color: black;
     }
 
     &[data-color="gray"] {

--- a/src/styles/components/tag.css
+++ b/src/styles/components/tag.css
@@ -1,19 +1,17 @@
 :root {
-    /* Tag color palette - some colors are shared with sticky-note
-    so we may want to define a more global color palette */
-    --tag-color-light_green: #74ff8d;
-    --tag-color-red: #ff5c5c;
-    --tag-color-cyan: #1dd0e8;
-    --tag-color-yellow: #e6d329;
-    --tag-color-magenta: #e91e63;
-    --tag-color-green: #16ba3a;
-    --tag-color-blue: #1f4ecf;
-    --tag-color-gray: #a9a9a9;
-    --tag-color-violet: #3410a2;
-    --tag-color-dark_green: #004b02;
-    --tag-color-dark_blue: #00316e;
-    --tag-color-dark_gray: #4a4a4a;
-    --tag-color-black: #0d0d0d;
+    --tag-color-red: rgb(255, 173, 173);
+    --tag-color-light_green: rgb(194, 235, 127);
+    --tag-color-cyan: rgb(168, 233, 255);
+    --tag-color-yellow: rgb(255, 237, 123);
+    --tag-color-magenta: rgb(255, 171, 236);
+    --tag-color-green: rgb(173, 240, 199);
+    --tag-color-blue: rgb(160, 196, 251);
+    --tag-color-gray: rgb(214, 214, 214);
+    --tag-color-violet: rgb(102, 49, 215);
+    --tag-color-dark_green: rgb(6, 116, 41);
+    --tag-color-dark_blue: rgb(48, 91, 171);
+    --tag-color-dark_gray: rgb(89, 89, 89);
+    --tag-color-black: rgb(26, 26, 26);
 }
 
 .a11ywb-tags-box {
@@ -36,13 +34,13 @@
 }
 
 .a11ywb-tag {
-  &[data-color="light_green"] {
-      background-color: var(--tag-color-light_green);
+  &[data-color="red"] {
+      background-color: var(--tag-color-red);
       color: black;
   }
 
-  &[data-color="red"] {
-      background-color: var(--tag-color-red);
+  &[data-color="light_green"] {
+      background-color: var(--tag-color-light_green);
       color: black;
   }
 
@@ -58,17 +56,17 @@
 
   &[data-color="magenta"] {
       background-color: var(--tag-color-magenta);
-      color: white;
+      color: black;
   }
 
   &[data-color="green"] {
       background-color: var(--tag-color-green);
-      color: white;
+      color: black;
   }
 
   &[data-color="blue"] {
       background-color: var(--tag-color-blue);
-      color: white;
+      color: black;
   }
 
   &[data-color="gray"] {


### PR DESCRIPTION
# Overview

We were using a different color scheme and to better match prototype list items to Miro board items, I updated the colors with Miro's.

Should apply to Sticky Notes and Tags
<img width="956" height="668" alt="image" src="https://github.com/user-attachments/assets/136b48f6-5b6b-45b8-95bb-6a42d2727bd6" />
