### PR TITLE
Fix: Flatten search result hierarchy

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,7 +8,8 @@ import { buildConnectorHierarchy } from '@utils/hierarchy-builder';
 import { openAddModal } from '@utils/open-modal';
 import { useBoardItems } from './hooks/useBoardItems';
 
-import { applyHierarchicalSearch, getSearchResultTotal, normalizeQuery } from '@utils/search';
+
+import { filterHierarchy, getSearchResultTotal, isDefaultFilter, normalizeQuery, SearchFilters } from '@utils/search';
 import { ALL_ITEM_TYPES, ALL_ITEM_TYPES_FILTER_OPTION, ITEM_TYPE_FILTER_OPTIONS } from '@config/search';
 
 const fallbackData = SampleItems as Item[];
@@ -18,32 +19,41 @@ const App: React.FC = () => {
   const [query, setQuery] = React.useState('');
   const [itemTypeFilter, setItemTypeFilter] = React.useState(ALL_ITEM_TYPES);
 
+  const deferredQuery = React.useDeferredValue(query);
+
+  const searchFilters: SearchFilters = {
+    query: normalizeQuery(deferredQuery),
+    filterByType: itemTypeFilter
+  };
+
+  const isFiltered = isDefaultFilter(searchFilters);
+
+  const boardItems = React.useMemo(() => {
+    return buildConnectorHierarchy(items);
+  }, [items]);
+
   const hierarchyBoard = React.useMemo(() => {
-    const children = buildConnectorHierarchy(items);
+    const filteredBoardItems = filterHierarchy(boardItems, searchFilters);
 
     const hierarchyRoot = {
       id: 'board',
       label: 'Board',
       type: 'board',
-      children,
+      children: filteredBoardItems,
     };
 
     return hierarchyRoot;
-  }, [items]);
+  }, [items, searchFilters.query, searchFilters.filterByType]);
 
-  const navigableItemCount = hierarchyBoard.children.reduce((acc, child) => {
+  const navigableItemCount = boardItems.reduce((acc, child) => {
     acc += child.metadata.treeChildCount + 1;
     return acc;
   }, 0);
   
   const searchResultTotal = React.useMemo(() => {
-    const normalizedQuery = normalizeQuery(query);
-    applyHierarchicalSearch(hierarchyBoard.children, { normalizedQuery, filterByType: itemTypeFilter });
-
     return getSearchResultTotal(hierarchyBoard.children);
-  }, [hierarchyBoard.children, query, itemTypeFilter]);
+  }, [hierarchyBoard.children, searchFilters.filterByType, searchFilters.query]);
 
-  // Update the callback to only set query state
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value);
   };
@@ -100,6 +110,7 @@ const App: React.FC = () => {
         type={hierarchyBoard.type as ItemType}
         label={hierarchyBoard.label}
         children={hierarchyBoard.children}
+        isFiltered={isFiltered}
       />
 
       <h2>Add Item to Board</h2>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRoot } from 'react-dom/client';
+import { createRoot, Root } from 'react-dom/client';
 import { type Item } from '@mirohq/websdk-types';
 import SampleItems from '@data/sample-items.json';
 import { HierarchyBoard } from '@components/hierarchy';
@@ -203,11 +203,22 @@ const App: React.FC = () => {
   );
 };
 
+declare global {
+  interface Window {
+    __a11ywbRoot?: Root;
+  }
+}
+
 const container = document.getElementById('a11ywb-root');
-const root = container ? createRoot(container) : null;
+
+if (container) {
+  window.__a11ywbRoot ??= createRoot(container);
+}
 
 function render() {
-  root?.render(<App />);
+  if (window.__a11ywbRoot) {
+    window.__a11ywbRoot.render(<App />);
+}
 }
 
 render();

--- a/src/components/hierarchy.tsx
+++ b/src/components/hierarchy.tsx
@@ -1,5 +1,5 @@
 import type { Frame, Item, StickyNote, Text } from '@mirohq/websdk-types';
-import { ConnectableItem, HierarchyItem, ItemType } from '@models/item';
+import { HierarchyItem, HierarchyItemType, ItemType } from '@models/item';
 import Tags from './tags';
 import React from 'react';
 import { getItemTypeConfig } from '@utils/items';
@@ -37,7 +37,7 @@ export interface HierarchyBoardProps {
   children?: HierarchyItem[];
 }
 
-export type TreeBoardItem = ConnectableItem;
+export type TreeBoardItem = HierarchyItemType;
 
 export interface TreeBoardItemProps {
   hierarchyItem: HierarchyItem<TreeBoardItem>;

--- a/src/components/hierarchy.tsx
+++ b/src/components/hierarchy.tsx
@@ -35,6 +35,7 @@ export interface HierarchyBoardProps {
   type: ItemType;
   label: string;
   children?: HierarchyItem[];
+  isFiltered?: boolean;
 }
 
 export type TreeBoardItem = HierarchyItemType;
@@ -53,7 +54,7 @@ const HierarchyListItem: React.FC<{ item: HierarchyItem }> = ({ item }) => {
   );
 };
 
-export const HierarchyBoard: React.FC<HierarchyBoardProps> = ({ type, label, children }) => {
+export const HierarchyBoard: React.FC<HierarchyBoardProps> = ({ type, label, children, isFiltered }) => {
   const listItems = children ?? [];
 
   return (
@@ -68,7 +69,9 @@ export const HierarchyBoard: React.FC<HierarchyBoardProps> = ({ type, label, chi
             {listItems.map((listItem) => <HierarchyListItem key={`board-child-${listItem.id}`} item={listItem} />)}
           </ul>
         )}
-        {listItems.length === 0 && <p>This board has no items.</p>}
+        {isFiltered && listItems.length === 0 && <p>No items match search filters.</p>}
+
+        {!isFiltered && listItems.length === 0 && <p>This board has no items.</p>}
       </div>
     </details>
   );

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -3,6 +3,11 @@ import { isStickyNote } from "./items";
 import { getColorConfig } from "./colors";
 import { ALL_ITEM_TYPES, ALL_ITEM_TYPES_FILTER_OPTION } from '@config/search';
 
+export interface SearchFilters {
+    query?: string; // assumes query is normalized already, so normalize outside,
+    filterByType: typeof ALL_ITEM_TYPES_FILTER_OPTION['type'] | ItemType
+};
+
 export function normalizeQuery(text: string): string {
     // https://www.codecademy.com/resources/docs/javascript/strings/normalize
     const normalized = text.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
@@ -34,8 +39,18 @@ export function getSearchableText(hierarchyItem: HierarchyItem): string {
     return normalizeQuery(query);
 }
 
-export function isMatch(hierarchyItem: HierarchyItem, query: string = ''): boolean {
-    if (!query) {
+export function isDefaultFilter(searchFilters: SearchFilters): boolean {
+    const { query, filterByType } = searchFilters;
+
+    return isQueryWhitespace(query) && filterByType === ALL_ITEM_TYPES;
+}
+
+export function isQueryWhitespace(query?: string): boolean {
+    return !query || /^\s*$/.test(query);
+}
+
+export function isTextMatch(hierarchyItem: HierarchyItem, query: string = ''): boolean {
+    if (isQueryWhitespace(query)) {
         return true;
     }
 
@@ -46,10 +61,52 @@ export function isMatch(hierarchyItem: HierarchyItem, query: string = ''): boole
     return queryTerms.every(queryTerm => searchableText.includes(queryTerm));
 }
 
+/**
+ * This version rewrites the original tree structure
+ * to flatten the list and only display direct matches or descendants of direct matches
+ */
+export function filterHierarchy(
+    items: HierarchyItem[],
+    searchOptions: SearchFilters,
+): HierarchyItem[] {
+
+    const { query, filterByType } = searchOptions;
+
+    const isMatchAll = isDefaultFilter(searchOptions);
+
+    if (isMatchAll) {
+        return [...items ];
+    }
+
+    const results = items.flatMap(item => {
+        const isMatchType = filterByType === ALL_ITEM_TYPES || item.type === filterByType;
+        const isMatchSelf = isMatchType && (isTextMatch(item, query));
+
+        const filteredChildren = filterHierarchy(item.children, searchOptions);
+
+        if (isMatchSelf) {
+            return item;
+        }
+
+        if (filteredChildren.length > 0) {
+            return filteredChildren;
+        }
+
+        // no matches in tree
+        return [];
+    })
+
+    return results;
+}
+
+/**
+ * This method does not rewrite the original hierarchy and only hides non-matches through CSS
+ * The whole tree of a direct match, whether an ancestor or a descendant are included
+ */
 export function applyHierarchicalSearch(
   items: HierarchyItem[],
   searchOptions: {
-    normalizedQuery: string, // assumes query is normalized already, so normalize outside,
+    normalizedQuery: string,
     filterByType: typeof ALL_ITEM_TYPES_FILTER_OPTION['type'] | ItemType
   }, 
   isChildOfMatch = false
@@ -60,7 +117,7 @@ export function applyHierarchicalSearch(
 
     for (const item of items) {
         const isParentOfMatch = applyHierarchicalSearch(item.children, searchOptions);
-        const isSelfMatch = isMatch(item, normalizedQuery);
+        const isSelfMatch = isTextMatch(item, normalizedQuery);
 
         let searchMatch: HierarchyItemMetadata['searchMatch'];
 


### PR DESCRIPTION
# Overview
Direct matches no longer display its entire ancestry, so screenreaders can immediately jump to the first result. For example, if a direct match is a 3-level deep sticky note, we no longer need to display the frame it is in and its parent and grandparent.

<img width="869" height="627" alt="image" src="https://github.com/user-attachments/assets/2040a188-972b-4fb6-ae59-6fb72202f037" />
