### PR TITLE
Edit Modal: Handle item placement when moving between frames or board

### DIFF
--- a/modals/components/EditModal.tsx
+++ b/modals/components/EditModal.tsx
@@ -6,6 +6,7 @@ import { InputElement } from '../inputs/InputElement';
 import { findFramePlacement, placeItem } from '@utils/item-placer';
 import { isConnectableItem } from '@utils/items';
 import { HierarchyItem } from '@models/item';
+import { disconnectFromParent } from '@utils/connections';
 
 type EditModalProps = {
   handleError: (message: string, error: unknown) => void;
@@ -54,8 +55,12 @@ export const EditModal = (props: EditModalProps) => {
         const existingParentId: string = (modalData.item as ItemWithParent)?.parentId ?? '';
 
         if (existingParentId) {
-          const existingParent = (await miro.board.getById(existingParentId)) as Frame;
-          await existingParent.remove(item);
+          const existingParent = (await miro.board.getById(existingParentId));
+
+          if (isConnectableItem(item)) {
+            disconnectFromParent(item, existingParent);
+          }
+
           await item.sync();
         }
 

--- a/modals/components/EditModal.tsx
+++ b/modals/components/EditModal.tsx
@@ -3,6 +3,9 @@ import { Connector, Frame, Group, Item, Tag } from '@mirohq/websdk-types';
 import { FormEvent, useEffect, useState } from 'react';
 import { notifyBoardUpdate } from '../../src/utils/board-sync';
 import { InputElement } from '../inputs/InputElement';
+import { findFramePlacement, placeItem } from '@utils/item-placer';
+import { isConnectableItem } from '@utils/items';
+import { HierarchyItem } from '@models/item';
 
 type EditModalProps = {
   handleError: (message: string, error: unknown) => void;
@@ -58,14 +61,31 @@ export const EditModal = (props: EditModalProps) => {
 
         if (parentId) {
           const parentFrame = (await miro.board.getById(parentId as string)) as Frame;
-          item.x = parentFrame.x + 1;
-          item.y = parentFrame.y + 1;
-          await item.sync();
-          await parentFrame.add(item);
+
+          if (isConnectableItem(item)) {
+            const hierarchyParent = { 
+              id: parentFrame.id,
+              label: parentFrame.title,
+              item: parentFrame,
+              level: 1,
+            } as HierarchyItem<Frame>; // bare minimum info for item placement algorithm
+            await placeItem(item, { parent: hierarchyParent, frame: parentFrame });
+          } else {
+            // for unsupported types
+            item.x = parentFrame.x + 1;
+            item.y = parentFrame.y + 1;
+            await item.sync();
+            await parentFrame.add(item);
+          }
         } else {
-          item.x = 0;
-          item.y = 0;
-          await item.sync();
+          // center items in board
+          const emptySpot = await findFramePlacement({ 
+            x: 0, 
+            y: 0,
+          });
+
+          item.x = emptySpot.x;
+          item.y = emptySpot.y;
         }
       }
 

--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -1,0 +1,15 @@
+import { Item } from "@mirohq/websdk-types";
+import { ConnectableItem } from "@models/item";
+import { isFrame } from "./items";
+
+export async function disconnectFromParent(item: ConnectableItem, parent: Item): Promise<void> {
+    if (isFrame(parent)) {
+        await parent.remove(item);
+    }
+
+    const connectors = await item.getConnectors();
+
+    await Promise.all(connectors.map(connector => miro.board.remove(connector)));
+
+    return;
+}

--- a/src/utils/item-placer.ts
+++ b/src/utils/item-placer.ts
@@ -16,13 +16,30 @@ export interface ItemPlacementOptions {
     siblings?: HierarchyItem[];
 }
 
+export async function getItemFrameId(
+    item: ConnectableItem, 
+    options: { parent?: HierarchyItem, frame?: Frame } = {}
+): Promise<Frame['id'] | null> {
+    const { frame, parent } = options;
+
+    if (frame?.id) {
+        return frame.id;
+    }
+
+    if (isHierarchyItem(parent?.item)) {
+        return isFrame(parent.item) ? parent.id : parent.item.parentId;
+    }
+
+    return item.parentId;
+}
+
 export async function placeItem(item: ConnectableItem, options: ItemPlacementOptions = {}): Promise<void> {
     const { parent } = options;
 
     if (isHierarchyItem(parent?.item)) {
         let frame: Frame | undefined = undefined;
 
-        let frameId = isFrame(parent.item) ? parent.id : parent.item.parentId;
+        const frameId = await getItemFrameId(item, { parent, frame: options.frame });
 
         if (frameId) {
             frame = await miro.board.getById(frameId) as Frame;
@@ -44,7 +61,7 @@ export async function placeItem(item: ConnectableItem, options: ItemPlacementOpt
                 };
 
                 if (parent.id !== frameId) {
-                    // only add connectors if parent is not a frame
+                    // only add connectors if parent exists and is not a frame
                     const connectorEndpoints = calculateConnectorEndpoints(parentRect, futurePlacement);
 
                     await miro.board.createConnector({


### PR DESCRIPTION
# Overview
When moving items within frames, follow the spiral placement strategy, but without adding connections.

When moving items to the board, remove any connections and parents.
Then place relative to the center of the board, avoiding any overlaps.

<img width="489" height="582" alt="image" src="https://github.com/user-attachments/assets/cbf287f5-3b1e-4119-840f-82a5a0736013" />
