### PR TITLE
Handle focus more agnostically

### DIFF
--- a/modals/index.tsx
+++ b/modals/index.tsx
@@ -13,14 +13,10 @@ const App: React.FC = () => {
   const [successMessage, setSuccessMessage] = React.useState<string>('');
 
   React.useEffect(() => {
-    const focusTitle = () => title?.current?.focus();
-
-    window.addEventListener('DOMContentLoaded', focusTitle);
-
-    return () => {
-      window.removeEventListener('DOMContentLoaded', focusTitle);
-    };
-  }, [window, title]);
+    if (modalData) {
+      requestAnimationFrame(() => title.current?.focus());
+    }
+  }, [modalData]);
 
   const fetchModalData = async () => {
     try {


### PR DESCRIPTION
The previous approach worked on Mac OS/VoiceOver but failed on Windows. The likely cause of this failure is a couple of race conditions that just happened to work out timing-wise on Mac. `DOMContentLoaded` potentially created these conditions where this event might've already fired before the effect could run and/or `modalData` might not have been ready.

This approach is different because it uses `requestAnimationFrame`, which waits until the browser paints and is a more standard way of handling focus after rendering.

Fix for issue #8 