### PR TITLE
Earcons: Play when selecting a color from the Add/Edit modals

### DIFF
--- a/modals/inputs/InputElement.tsx
+++ b/modals/inputs/InputElement.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { ColorOptions } from './ColorOptions';
 import { RichTextInput } from './RichTextInput';
 import type { AddModalProperties, EditModalProperties } from '../../src/models/modals';
 import { Frame } from '@mirohq/websdk-types';
+import { getEarcon } from '@utils/a11y';
 
 type AddField =
   | NonNullable<AddModalProperties['frameFields']>[number]
@@ -16,6 +17,7 @@ type Field = AddField | EditField;
 type InputElementProps = {
   field: Field;
   parentFrames?: Frame[];
+  onFocusColorOption?: React.FocusEventHandler;
 };
 
 const getReadableFieldName = (fieldName: string): string => {
@@ -36,12 +38,20 @@ export const InputElement = (props: InputElementProps): React.ReactElement | nul
   const required = field.required ?? false;
   const readableFieldName = getReadableFieldName(field.fieldName);
 
+  const handleColorSelectChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    const audioSrc = getEarcon({ color: e.target.value });
+    const audio = new Audio(audioSrc);
+
+    audio.play();
+
+  }, []);
+
   switch (field.fieldType) {
     case 'color_map':
       return (
         <label className="ally-wb-edit-form-label">
           <span className="ally-wb-edit-form-label-text">{readableFieldName}</span>
-          <select name={field.fieldName} id={field.fieldName} required={required}>
+          <select name={field.fieldName} id={field.fieldName} required={required} size={5} onChange={handleColorSelectChange}>
             <ColorOptions currentColor={currentValue ?? defaultValue ?? ''} />
           </select>
         </label>

--- a/src/components/hierarchy.tsx
+++ b/src/components/hierarchy.tsx
@@ -395,7 +395,7 @@ const StickyNoteTypeBoardItem: React.FC<StickyNoteTypeBoardItemProps> = ({ hiera
   const colorKey = hierarchyItem.item?.style.fillColor;
   const colorLabel = getColorConfig(hierarchyItem.item)?.displayLabel;
 
-  const { onFocus } = useEarcon({ category: hierarchyItem.item })
+  const { onFocus } = useEarcon({ category: hierarchyItem.item });
 
   return (
     <TreeBoardItem hierarchyItem={hierarchyItem} onFocus={onFocus}>

--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -20,7 +20,7 @@ export const useAudio = (
       audioRef.current = new Audio(src);
     };
 
-    window.addEventListener('keydown', init, { once: true });
+    window.addEventListener('keydown', init, { once: false });
 
     return () => window.removeEventListener('keydown', init);
   }, [src, shouldPlay]);

--- a/src/hooks/useEarcon.ts
+++ b/src/hooks/useEarcon.ts
@@ -1,22 +1,12 @@
-import { isStickyNote } from '@utils/items';
 import { useAudio } from './useAudio';
-import { HierarchyItemType } from '@models/item';
-import { EarconRegistry } from '@config/earcons';
+import { EarconOptions, getEarcon } from '@utils/a11y';
 
-interface UseEarconOptions {
-  category: HierarchyItemType;
-  enabled?: boolean;
+interface UseEarconOptions extends EarconOptions {
+  enabled?: boolean; 
 }
 
-export const useEarcon = ({ category, enabled }: UseEarconOptions) => {
-    let audioSrc: string | undefined;
+export const useEarcon = ({ category, color, enabled }: UseEarconOptions) => {
+  const audioSrc = getEarcon({ category, color });
 
-    if (isStickyNote(category)) {
-        const config = EarconRegistry.sticky_note[category.style.fillColor];
-
-        if (config.audio) {
-            audioSrc = config.audio;
-        }
-    }
   return useAudio(audioSrc ?? '', { enabled: enabled });
 };

--- a/src/utils/a11y.ts
+++ b/src/utils/a11y.ts
@@ -1,0 +1,40 @@
+import { HierarchyItem, HierarchyItemType } from "@models/item";
+import { isStickyNote } from "./items";
+import { EarconRegistry } from "@config/earcons";
+import { StickyNoteColor } from "@mirohq/websdk-types";
+
+export function getA11yLabelledBy(hierarchyItem: HierarchyItem): string {
+    let parts: string[] = [`heading`, 'metadata-tree'];
+
+    if (isStickyNote(hierarchyItem.item)) {
+        parts.push(`metadata-color`);
+        parts.push(`metadata-tags`);
+    }
+
+    return parts.map(part => `${hierarchyItem.id}-${part}`).join(" ");
+}
+
+export interface EarconOptions {
+  category?: HierarchyItemType;
+  color?: string;
+}
+
+export function getEarcon({ category, color }: EarconOptions): string | undefined {
+    let audioSrc: string | undefined;
+
+    if (isStickyNote(category)) {
+        const config = EarconRegistry.sticky_note[category.style.fillColor];
+
+        if (config?.audio) {
+            audioSrc = config.audio;
+        }
+    } else if (color) {
+        const config = EarconRegistry.sticky_note[color as StickyNoteColor];
+
+        if (config?.audio) {
+            audioSrc = config.audio;
+        }
+    }
+
+    return audioSrc;
+}


### PR DESCRIPTION
# Changes
- I transformed the `<select>` input to a combobox-like version (by simply setting a `size` attribute) so we can hook in our earcon play function when an option if focused on.
- Using the up and down arrow keys should play the earcon.

<img width="707" height="505" alt="image" src="https://github.com/user-attachments/assets/da78b8fd-845d-4a1a-9eff-ea62480af3b6" />

