### PR TITLE
Accordion component

### DIFF
--- a/src/assets/icons/arrow_drop_down.svg
+++ b/src/assets/icons/arrow_drop_down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="000"><path d="M480-360 280-560h400L480-360Z"/></svg>

--- a/src/assets/icons/arrow_drop_up.svg
+++ b/src/assets/icons/arrow_drop_up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="000"><path d="m280-400 200-200 200 200H280Z"/></svg>

--- a/src/assets/icons/arrow_right.svg
+++ b/src/assets/icons/arrow_right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="000"><path d="M400-280v-400l200 200-200 200Z"/></svg>

--- a/src/components/accordion.tsx
+++ b/src/components/accordion.tsx
@@ -1,0 +1,94 @@
+import { Dispatch, FocusEvent, ReactNode, useCallback, useState } from 'react';
+import { HeadingLevel, HeadingTagMap } from './titled-section';
+
+type Summary = {
+  text: string | undefined;
+  className?: string;
+  headingLevel?: HeadingLevel;
+  description?: string;
+  focusAction?: (event: FocusEvent) => void;
+  content?: ReactNode;
+};
+
+type AccordionProps = {
+  id: string;
+  defaultOpen: boolean;
+  summary: Summary;
+  children: ReactNode;
+  detailsClassNames?: string[];
+  ['data-subtype']?: string;
+};
+
+type SummaryHeadingProps = Pick<AccordionProps, 'summary' | 'id'> & {
+  open: boolean;
+  setOpen: Dispatch<boolean>;
+};
+
+const SummaryHeading = (props: SummaryHeadingProps) => {
+  const { summary, id, open, setOpen } = props;
+
+  const HeadingTag = summary?.headingLevel
+    ? (HeadingTagMap[summary.headingLevel] as keyof JSX.IntrinsicElements)
+    : '';
+
+  const handleFocus = useCallback(
+    (e: React.FocusEvent) => {
+      if (e.currentTarget.contains(e.relatedTarget as Node)) {
+        return;
+      }
+
+      if (summary.focusAction) {
+        summary.focusAction(e);
+      }
+    },
+    [summary.focusAction],
+  );
+
+  const button = (
+    <button
+      aria-expanded={open}
+      aria-controls={id}
+      onClick={() => setOpen(!open)}
+      className={`a11ywb-accordion-summary__button a11ywb-accordion-summary__button--${open ? 'open' : 'closed'}`}
+    >
+      {summary.text}
+    </button>
+  );
+
+  if (HeadingTag) {
+    return (
+      <HeadingTag style={{ width: '100%' }} onFocus={handleFocus}>
+        {button}
+      </HeadingTag>
+    );
+  }
+
+  return button;
+};
+
+export const Accordion = (props: AccordionProps) => {
+  const { defaultOpen, id, summary, children, detailsClassNames = [] } = props;
+  const [open, setOpen] = useState<boolean>(defaultOpen);
+
+  const content_id = `allywb-accordion-content-${id}`;
+
+  return (
+    <div
+      className={`a11ywb-accordion ${detailsClassNames?.join(' ')}`}
+      data-subtype={props['data-subtype']}
+    >
+      <header
+        className={summary?.className ?? 'a11ywb-accordion-header'}
+        onFocus={summary?.focusAction}
+      >
+        <SummaryHeading summary={summary} id={content_id} open={open} setOpen={setOpen} />
+
+        {summary?.description && <div dangerouslySetInnerHTML={{ __html: summary.description }} />}
+      </header>
+
+      {summary?.content}
+
+      {open && <div id={content_id} children={children} />}
+    </div>
+  );
+};

--- a/src/components/accordion.tsx
+++ b/src/components/accordion.tsx
@@ -49,6 +49,7 @@ const SummaryHeading = (props: SummaryHeadingProps) => {
       aria-expanded={open}
       aria-controls={id}
       onClick={() => setOpen(!open)}
+      onFocus={handleFocus}
       className={`a11ywb-accordion-summary__button a11ywb-accordion-summary__button--${open ? 'open' : 'closed'}`}
     >
       {summary.text}
@@ -70,7 +71,7 @@ export const Accordion = (props: AccordionProps) => {
   const { defaultOpen, id, summary, children, detailsClassNames = [] } = props;
   const [open, setOpen] = useState<boolean>(defaultOpen);
 
-  const content_id = `allywb-accordion-content-${id}`;
+  const content_id = `a11ywb-accordion-content-${id}`;
 
   return (
     <div

--- a/src/components/hierarchy.tsx
+++ b/src/components/hierarchy.tsx
@@ -75,7 +75,7 @@ export const HierarchyBoard: React.FC<HierarchyBoardProps> = ({
       }}
       children={
         <>
-          <section role="group" aria-labelledby="button-group-add-item-to-board">
+          <section role="toolbar" aria-labelledby="button-group-add-item-to-board">
             <h2 id="button-group-add-item-to-board">Add Item to Board</h2>
             <button
               type="button"
@@ -269,9 +269,11 @@ const TreeBoardItem: React.FC<TreeBoardItemProps> = ({
 
   const itemSummary = getItemLabel(hierarchyItem, { onFocus });
 
+  const accordionId = `${hierarchyItem.type}-${hierarchyItem.id}`
+
   return (
     <Accordion
-      id={hierarchyItem.type + hierarchyItem.id}
+      id={accordionId}
       defaultOpen={!!metadata.searchMatch && metadata.searchMatch !== 'default'}
       data-subtype={subtype}
       detailsClassNames={['a11ywb-board-item', `a11ywb-board-item--type-${hierarchyItem.type}`]}
@@ -281,7 +283,7 @@ const TreeBoardItem: React.FC<TreeBoardItemProps> = ({
         description: itemSummary.headingDescription,
         focusAction: onFocus,
         content: (
-          <div className="a11ywb-board-item__metadata">
+          <div role="status" className="a11ywb-board-item__metadata">
             {metadata && (
               <>
                 <p>{hierarchyItem.metadata?.treeChildCount} total sub-topics</p>
@@ -320,100 +322,103 @@ const TextTypeBoardItem: React.FC<TextTypeBoardItemProps> = ({ hierarchyItem }) 
 
   return (
     <BoardItem hierarchyItem={hierarchyItem}>
-      <button
-        id={`edit-${hierarchyItem.id}`}
-        type="button"
-        onClick={() =>
-          openEditModal({
-            item: hierarchyItem.item,
-            title: 'Edit Text',
-            fields: [
-              {
-                fieldName: 'content',
-                currentValue: hierarchyItem.label,
-                fieldType: 'extended_rich_text',
-                required: true,
-              },
-              {
-                fieldName: 'parentId',
-                currentValue: hierarchyItem.item.parentId ?? '',
-                fieldType: 'parent',
-              },
-            ],
-          })
-        }
-      >
-        Edit Text
-      </button>
-      <button
-        id={`connect-${hierarchyItem.id}`}
-        type="button"
-        onClick={() =>
-          openConnectModal({
-            item: hierarchyItem.item,
-            title: 'Text Connections',
-          })
-        }
-      >
-        Text Connections
-      </button>
-      <button
-        id={`delete-${hierarchyItem.id}`}
-        type="button"
-        onClick={() =>
-          openDeleteModal({
-            id: hierarchyItem.id,
-            title: 'Delete Text',
-          })
-        }
-      >
-        Delete Text
-      </button>
 
-      <button
-        type="button"
-        onClick={() =>
-          openAddModal({
-            title: 'Add child Sticky Note',
-            stickyNoteFields: [
-              {
-                fieldName: 'content',
-                fieldType: 'rich_text',
-                required: true,
-              },
-              {
-                fieldName: 'style.fillColor',
-                fieldType: 'color_map',
-                defaultValue: hierarchyItem.item.style.fillColor,
-              },
-            ],
-            hierarchyParentId: hierarchyItem.id,
-            hierarchyItem,
-          })
-        }
-      >
-        Add child Sticky Note
-      </button>
+      <div role="toolbar" aria-label="Text Actions">
+        <button
+          id={`edit-${hierarchyItem.id}`}
+          type="button"
+          onClick={() =>
+            openEditModal({
+              item: hierarchyItem.item,
+              title: 'Edit Text',
+              fields: [
+                {
+                  fieldName: 'content',
+                  currentValue: hierarchyItem.label,
+                  fieldType: 'extended_rich_text',
+                  required: true,
+                },
+                {
+                  fieldName: 'parentId',
+                  currentValue: hierarchyItem.item.parentId ?? '',
+                  fieldType: 'parent',
+                },
+              ],
+            })
+          }
+        >
+          Edit Text
+        </button>
+        <button
+          id={`connect-${hierarchyItem.id}`}
+          type="button"
+          onClick={() =>
+            openConnectModal({
+              item: hierarchyItem.item,
+              title: 'Text Connections',
+            })
+          }
+        >
+          Text Connections
+        </button>
+        <button
+          id={`delete-${hierarchyItem.id}`}
+          type="button"
+          onClick={() =>
+            openDeleteModal({
+              id: hierarchyItem.id,
+              title: 'Delete Text',
+            })
+          }
+        >
+          Delete Text
+        </button>
 
-      <button
-        type="button"
-        onClick={() =>
-          openAddModal({
-            title: 'Add child Text',
-            textFields: [
-              {
-                fieldName: 'content',
-                fieldType: 'extended_rich_text',
-                required: true,
-              },
-            ],
-            hierarchyParentId: hierarchyItem.id,
-            hierarchyItem,
-          })
-        }
-      >
-        Add child Text
-      </button>
+        <button
+          type="button"
+          onClick={() =>
+            openAddModal({
+              title: 'Add child Sticky Note',
+              stickyNoteFields: [
+                {
+                  fieldName: 'content',
+                  fieldType: 'rich_text',
+                  required: true,
+                },
+                {
+                  fieldName: 'style.fillColor',
+                  fieldType: 'color_map',
+                  defaultValue: hierarchyItem.item.style.fillColor,
+                },
+              ],
+              hierarchyParentId: hierarchyItem.id,
+              hierarchyItem,
+            })
+          }
+        >
+          Add child Sticky Note
+        </button>
+
+        <button
+          type="button"
+          onClick={() =>
+            openAddModal({
+              title: 'Add child Text',
+              textFields: [
+                {
+                  fieldName: 'content',
+                  fieldType: 'extended_rich_text',
+                  required: true,
+                },
+              ],
+              hierarchyParentId: hierarchyItem.id,
+              hierarchyItem,
+            })
+          }
+        >
+          Add child Text
+        </button>
+      </div>
 
       {hierarchyChildren?.length ? (
         <ul>
@@ -441,108 +446,111 @@ const StickyNoteTypeBoardItem: React.FC<StickyNoteTypeBoardItemProps> = ({ hiera
       </span>
       <Tags tags={hierarchyItem.tags} />
 
-      <button
-        id={`edit-${hierarchyItem.id}`}
-        type="button"
-        onClick={() =>
-          openEditModal({
-            item: hierarchyItem.item,
-            title: 'Edit Sticky Note',
-            fields: [
-              {
-                fieldName: 'content',
-                currentValue: hierarchyItem.label,
-                fieldType: 'rich_text',
-                required: true,
-              },
-              {
-                fieldName: 'style.fillColor',
-                currentValue: hierarchyItem.item.style.fillColor,
-                fieldType: 'color_map',
-                required: false,
-              },
-              {
-                fieldName: 'parentId',
-                currentValue: hierarchyItem.item.parentId ?? '',
-                fieldType: 'parent',
-              },
-            ],
-          })
-        }
-      >
-        Edit Sticky Note
-      </button>
 
-      <button
-        id={`connect-${hierarchyItem.id}`}
-        type="button"
-        onClick={() =>
-          openConnectModal({
-            item: hierarchyItem.item,
-            title: 'Sticky Note Connections',
-          })
-        }
-      >
-        Sticky Note Connections
-      </button>
+      <div role="toolbar" aria-label="Sticky Note Actions">
+        <button
+          id={`edit-${hierarchyItem.id}`}
+          type="button"
+          onClick={() =>
+            openEditModal({
+              item: hierarchyItem.item,
+              title: 'Edit Sticky Note',
+              fields: [
+                {
+                  fieldName: 'content',
+                  currentValue: hierarchyItem.label,
+                  fieldType: 'rich_text',
+                  required: true,
+                },
+                {
+                  fieldName: 'style.fillColor',
+                  currentValue: hierarchyItem.item.style.fillColor,
+                  fieldType: 'color_map',
+                  required: false,
+                },
+                {
+                  fieldName: 'parentId',
+                  currentValue: hierarchyItem.item.parentId ?? '',
+                  fieldType: 'parent',
+                },
+              ],
+            })
+          }
+        >
+          Edit Sticky Note
+        </button>
 
-      <button
-        id={`delete-${hierarchyItem.id}`}
-        type="button"
-        onClick={() =>
-          openDeleteModal({
-            id: hierarchyItem.id,
-            title: 'Delete Sticky Note',
-          })
-        }
-      >
-        Delete Sticky Note
-      </button>
+        <button
+          id={`connect-${hierarchyItem.id}`}
+          type="button"
+          onClick={() =>
+            openConnectModal({
+              item: hierarchyItem.item,
+              title: 'Sticky Note Connections',
+            })
+          }
+        >
+          Sticky Note Connections
+        </button>
 
-      <button
-        type="button"
-        onClick={() =>
-          openAddModal({
-            title: 'Add child Sticky Note',
-            stickyNoteFields: [
-              {
-                fieldName: 'content',
-                fieldType: 'rich_text',
-                required: true,
-              },
-              {
-                fieldName: 'style.fillColor',
-                fieldType: 'color_map',
-                defaultValue: hierarchyItem.item.style.fillColor,
-              },
-            ],
-            hierarchyParentId: hierarchyItem.id,
-            hierarchyItem,
-          })
-        }
-      >
-        Add child Sticky Note
-      </button>
+        <button
+          id={`delete-${hierarchyItem.id}`}
+          type="button"
+          onClick={() =>
+            openDeleteModal({
+              id: hierarchyItem.id,
+              title: 'Delete Sticky Note',
+            })
+          }
+        >
+          Delete Sticky Note
+        </button>
 
-      <button
-        type="button"
-        onClick={() =>
-          openAddModal({
-            title: 'Add child Text',
-            textFields: [
-              {
-                fieldName: 'content',
-                fieldType: 'extended_rich_text',
-                required: true,
-              },
-            ],
-            hierarchyParentId: hierarchyItem.id,
-            hierarchyItem,
-          })
-        }
-      >
-        Add child Text
-      </button>
+        <button
+          type="button"
+          onClick={() =>
+            openAddModal({
+              title: 'Add child Sticky Note',
+              stickyNoteFields: [
+                {
+                  fieldName: 'content',
+                  fieldType: 'rich_text',
+                  required: true,
+                },
+                {
+                  fieldName: 'style.fillColor',
+                  fieldType: 'color_map',
+                  defaultValue: hierarchyItem.item.style.fillColor,
+                },
+              ],
+              hierarchyParentId: hierarchyItem.id,
+              hierarchyItem,
+            })
+          }
+        >
+          Add child Sticky Note
+        </button>
+
+        <button
+          type="button"
+          onClick={() =>
+            openAddModal({
+              title: 'Add child Text',
+              textFields: [
+                {
+                  fieldName: 'content',
+                  fieldType: 'extended_rich_text',
+                  required: true,
+                },
+              ],
+              hierarchyParentId: hierarchyItem.id,
+              hierarchyItem,
+            })
+          }
+        >
+          Add child Text
+        </button>
+      </div>
     </TreeBoardItem>
   );
 };
@@ -554,82 +562,84 @@ const ClusterTypeBoardItem: React.FC<ClusterTypeBoardItemProps> = ({ hierarchyIt
 const FrameTypeBoardItem: React.FC<FrameTypeBoardItemProps> = ({ hierarchyItem }) => {
   return (
     <TreeBoardItem hierarchyItem={hierarchyItem}>
-      <button
-        id={`edit-${hierarchyItem.id}`}
-        type="button"
-        onClick={() =>
-          openEditModal({
-            item: hierarchyItem.item,
-            title: 'Edit Frame',
-            fields: [
-              {
-                fieldName: 'title',
-                currentValue: hierarchyItem.label,
-                fieldType: 'text',
-                required: true,
-              },
-            ],
-          })
-        }
-      >
-        Edit Frame
-      </button>
+      <div role="toolbar" aria-label="Frame Actions">
+        <button
+          id={`edit-${hierarchyItem.id}`}
+          type="button"
+          onClick={() =>
+            openEditModal({
+              item: hierarchyItem.item,
+              title: 'Edit Frame',
+              fields: [
+                {
+                  fieldName: 'title',
+                  currentValue: hierarchyItem.label,
+                  fieldType: 'text',
+                  required: true,
+                },
+              ],
+            })
+          }
+        >
+          Edit Frame
+        </button>
 
-      <button
-        id={`delete-${hierarchyItem.id}`}
-        type="button"
-        onClick={() =>
-          openDeleteModal({
-            id: hierarchyItem.id,
-            title: 'Delete Frame',
-          })
-        }
-      >
-        Delete Frame
-      </button>
-      <button
-        type="button"
-        onClick={() =>
-          openAddModal({
-            title: 'Add Sticky Note in Frame',
-            stickyNoteFields: [
-              {
-                fieldName: 'content',
-                fieldType: 'rich_text',
-                required: true,
-              },
-              {
-                fieldName: 'style.fillColor',
-                fieldType: 'color_map',
-              },
-            ],
-            hierarchyParentId: hierarchyItem.id,
-            hierarchyItem,
-          })
-        }
-      >
-        Add Sticky Note in Frame
-      </button>
+        <button
+          id={`delete-${hierarchyItem.id}`}
+          type="button"
+          onClick={() =>
+            openDeleteModal({
+              id: hierarchyItem.id,
+              title: 'Delete Frame',
+            })
+          }
+        >
+          Delete Frame
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            openAddModal({
+              title: 'Add Sticky Note in Frame',
+              stickyNoteFields: [
+                {
+                  fieldName: 'content',
+                  fieldType: 'rich_text',
+                  required: true,
+                },
+                {
+                  fieldName: 'style.fillColor',
+                  fieldType: 'color_map',
+                },
+              ],
+              hierarchyParentId: hierarchyItem.id,
+              hierarchyItem,
+            })
+          }
+        >
+          Add Sticky Note in Frame
+        </button>
 
-      <button
-        type="button"
-        onClick={() =>
-          openAddModal({
-            title: 'Add Text in Frame',
-            textFields: [
-              {
-                fieldName: 'content',
-                fieldType: 'extended_rich_text',
-                required: true,
-              },
-            ],
-            hierarchyParentId: hierarchyItem.id,
-            hierarchyItem,
-          })
-        }
-      >
-        Add Text in Frame
-      </button>
+        <button
+          type="button"
+          onClick={() =>
+            openAddModal({
+              title: 'Add Text in Frame',
+              textFields: [
+                {
+                  fieldName: 'content',
+                  fieldType: 'extended_rich_text',
+                  required: true,
+                },
+              ],
+              hierarchyParentId: hierarchyItem.id,
+              hierarchyItem,
+            })
+          }
+        >
+          Add Text in Frame
+        </button>
+      </div>
     </TreeBoardItem>
   );
 };

--- a/src/components/hierarchy.tsx
+++ b/src/components/hierarchy.tsx
@@ -1,11 +1,12 @@
 import type { Frame, Item, StickyNote, Text } from '@mirohq/websdk-types';
 import { HierarchyItem, HierarchyItemType, ItemType } from '@models/item';
 import Tags from './tags';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { getItemTypeConfig } from '@utils/items';
 import { getColorConfig } from '@utils/colors';
 import { openAddModal, openConnectModal, openDeleteModal, openEditModal } from '@utils/open-modal';
 import { useEarcon } from '../hooks/useEarcon';
+import { Accordion } from './accordion';
 
 export interface HierarchyProps {
   hierarchyItem: HierarchyItem<Item>;
@@ -56,109 +57,120 @@ const HierarchyListItem: React.FC<{ item: HierarchyItem }> = ({ item }) => {
   );
 };
 
-export const HierarchyBoard: React.FC<HierarchyBoardProps> = ({ type, label, children, isFiltered }) => {
+export const HierarchyBoard: React.FC<HierarchyBoardProps> = ({
+  type,
+  label,
+  children,
+  isFiltered,
+}) => {
   const listItems = children ?? [];
 
   return (
-    <details className="a11ywb-board a11ywb-accordion" open={true}>
-      <summary className="a11ywb-accordion-header">
-        {type}: {label}
-      </summary>
+    <Accordion
+      id="a11ywb-board-accordion"
+      defaultOpen
+      detailsClassNames={['a11ywb-board']}
+      summary={{
+        text: `${type}: ${label}`,
+      }}
+      children={
+        <>
+          <section role="group" aria-labelledby="button-group-add-item-to-board">
+            <h2 id="button-group-add-item-to-board">Add Item to Board</h2>
+            <button
+              type="button"
+              onClick={() =>
+                openAddModal({
+                  title: 'Add Frame',
+                  frameFields: [
+                    {
+                      fieldName: 'title',
+                      fieldType: 'text',
+                      required: true,
+                    },
+                    {
+                      fieldName: 'style.fillColor',
+                      fieldType: 'color',
+                    },
+                    {
+                      fieldName: 'width',
+                      fieldType: 'number',
+                      required: true,
+                      inputProps: {
+                        value: 700,
+                      },
+                    },
+                    {
+                      fieldName: 'height',
+                      fieldType: 'number',
+                      required: true,
+                      inputProps: {
+                        value: 500,
+                      },
+                    },
+                  ],
+                })
+              }
+            >
+              Add Frame
+            </button>
 
-      <section>
-        <h2>Add Item to Board</h2>
-        <button
-          type="button"
-          onClick={() =>
-            openAddModal({
-              title: 'Add Frame',
-              frameFields: [
-                {
-                  fieldName: 'title',
-                  fieldType: 'text',
-                  required: true,
-                },
-                {
-                  fieldName: 'style.fillColor',
-                  fieldType: 'color',
-                },
-                {
-                  fieldName: 'width',
-                  fieldType: 'number',
-                  required: true,
-                  inputProps: {
-                    value: 700,
-                  },
-                },
-                {
-                  fieldName: 'height',
-                  fieldType: 'number',
-                  required: true,
-                  inputProps: {
-                    value: 500,
-                  },
-                },
-              ],
-            })
-          }
-        >
-          Add Frame
-        </button>
+            <button
+              type="button"
+              onClick={() =>
+                openAddModal({
+                  title: 'Add Sticky Note',
+                  stickyNoteFields: [
+                    {
+                      fieldName: 'content',
+                      fieldType: 'rich_text',
+                      required: true,
+                    },
+                    {
+                      fieldName: 'style.fillColor',
+                      fieldType: 'color_map',
+                    },
+                  ],
+                })
+              }
+            >
+              Add Sticky Note
+            </button>
 
-        <button
-          type="button"
-          onClick={() =>
-            openAddModal({
-              title: 'Add Sticky Note',
-              stickyNoteFields: [
-                {
-                  fieldName: 'content',
-                  fieldType: 'rich_text',
-                  required: true,
-                },
-                {
-                  fieldName: 'style.fillColor',
-                  fieldType: 'color_map',
-                },
-              ],
-            })
-          }
-        >
-          Add Sticky Note
-        </button>
+            <button
+              type="button"
+              onClick={() =>
+                openAddModal({
+                  title: 'Add Text',
+                  textFields: [
+                    {
+                      fieldName: 'content',
+                      fieldType: 'extended_rich_text',
+                      required: true,
+                    },
+                  ],
+                })
+              }
+            >
+              Add Text
+            </button>
+          </section>
 
-        <button
-          type="button"
-          onClick={() =>
-            openAddModal({
-              title: 'Add Text',
-              textFields: [
-                {
-                  fieldName: 'content',
-                  fieldType: 'extended_rich_text',
-                  required: true,
-                },
-              ],
-            })
-          }
-        >
-          Add Text
-        </button>
-      </section>
+          <div className="a11ywb-accordion__contents">
+            {listItems.length > 0 && (
+              <ul>
+                {listItems.map((listItem) => (
+                  <HierarchyListItem key={`board-child-${listItem.id}`} item={listItem} />
+                ))}
+              </ul>
+            )}
+            {isFiltered && listItems.length === 0 && <p>No items match search filters.</p>}
 
-      <div className="a11ywb-accordion__contents">
-        {listItems.length > 0 && (
-          <ul>
-            {listItems.map((listItem) => (
-              <HierarchyListItem key={`board-child-${listItem.id}`} item={listItem} />
-            ))}
-          </ul>
-        )}
-        {isFiltered && listItems.length === 0 && <p>No items match search filters.</p>}
-
-        {!isFiltered && listItems.length === 0 && <p>This board has no items.</p>}
-      </div>
-    </details>
+            {!isFiltered && listItems.length === 0 && <p>This board has no items.</p>}
+          </div>
+        </>
+      }
+    />
   );
 };
 
@@ -166,7 +178,15 @@ interface GetItemLabelOptions {
   onFocus?: React.FocusEventHandler | undefined;
 }
 
-const getItemLabel = (hierarchyItem: HierarchyItem, options: GetItemLabelOptions = {}) => {
+const getItemLabel = (
+  hierarchyItem: HierarchyItem,
+  options: GetItemLabelOptions = {},
+): {
+  headingLevel: 'h2' | 'h3';
+  headingText: string | undefined;
+  headingDescription?: string;
+  node: React.ReactNode;
+} => {
   const usesRichText =
     hierarchyItem?.label?.startsWith('<p>') ||
     hierarchyItem?.label?.startsWith('<ul>') ||
@@ -177,44 +197,62 @@ const getItemLabel = (hierarchyItem: HierarchyItem, options: GetItemLabelOptions
   const { onFocus } = options;
 
   if (usesRichText && hasParent) {
-    return (
-      <>
-        <h3 onFocus={onFocus}>{itemTypeLabel}</h3>
-        <div dangerouslySetInnerHTML={{ __html: hierarchyItem.label }} />
-      </>
-    );
+    return {
+      headingLevel: 'h3',
+      headingText: itemTypeLabel,
+      headingDescription: hierarchyItem.label,
+      node: (
+        <>
+          <h3 onFocus={onFocus}>{itemTypeLabel}</h3>
+          <div dangerouslySetInnerHTML={{ __html: hierarchyItem.label }} />
+        </>
+      ),
+    };
   }
 
   if (!usesRichText && hasParent) {
-    return (
-      <>
-        <h3 onFocus={onFocus}>
-          {itemTypeLabel}: {hierarchyItem.label}
-        </h3>
-      </>
-    );
+    return {
+      headingLevel: 'h3',
+      headingText: `${itemTypeLabel}: ${hierarchyItem.label}`,
+      node: (
+        <>
+          <h3 onFocus={onFocus}>
+            {itemTypeLabel}: {hierarchyItem.label}
+          </h3>
+        </>
+      ),
+    };
   }
 
   if (usesRichText && !hasParent) {
-    return (
-      <>
-        <h2 onFocus={onFocus}>{itemTypeLabel}</h2>
-        <div dangerouslySetInnerHTML={{ __html: hierarchyItem.label }} />
-      </>
-    );
+    return {
+      headingLevel: 'h2',
+      headingText: itemTypeLabel,
+      headingDescription: hierarchyItem.label,
+      node: (
+        <>
+          <h2 onFocus={onFocus}>{itemTypeLabel}</h2>
+          <div dangerouslySetInnerHTML={{ __html: hierarchyItem.label }} />
+        </>
+      ),
+    };
   }
 
-  return (
-    <h2 onFocus={onFocus}>
-      {itemTypeLabel}: {hierarchyItem.label}
-    </h2>
-  );
+  return {
+    headingLevel: 'h2',
+    headingText: `${itemTypeLabel}: ${hierarchyItem.label}`,
+    node: (
+      <h2 onFocus={onFocus}>
+        {itemTypeLabel}: {hierarchyItem.label}
+      </h2>
+    ),
+  };
 };
 
 const BoardItem: React.FC<BoardItemProps<Item>> = ({ hierarchyItem, children }) => {
   return (
     <article className={`a11ywb-board-item a11ywb-board-item--type-${hierarchyItem.type}`}>
-      {getItemLabel(hierarchyItem)}
+      {getItemLabel(hierarchyItem).node}
       {children}
     </article>
   );
@@ -224,38 +262,32 @@ const TreeBoardItem: React.FC<TreeBoardItemProps> = ({ hierarchyItem, subtype, c
   const listItems = hierarchyItem.children ?? [];
   const metadata = hierarchyItem.metadata;
 
-  const handleFocus = useCallback((e: React.FocusEvent) => {
-    if (e.currentTarget.contains(e.relatedTarget as Node)) {
-      return;
-    }
-
-    if (onFocus) {
-      onFocus(e);
-    }
-  }, [onFocus]);
+  const itemSummary = getItemLabel(hierarchyItem, { onFocus });
 
   return (
-    <details
-      className={`a11ywb-accordion a11ywb-board-item a11ywb-board-item--type-${hierarchyItem.type}`}
-      open={!!metadata.searchMatch && metadata.searchMatch !== 'default'}
+    <Accordion
+      id={hierarchyItem.type + hierarchyItem.id}
+      defaultOpen={!!metadata.searchMatch && metadata.searchMatch !== 'default'}
       data-subtype={subtype}
+      detailsClassNames={['a11ywb-board-item', `a11ywb-board-item--type-${hierarchyItem.type}`]}
+      summary={{
+        text: itemSummary.headingText,
+        headingLevel: itemSummary.headingLevel,
+        description: itemSummary.headingDescription,
+        focusAction: onFocus,
+        content: (
+          <div className="a11ywb-board-item__metadata">
+            {metadata && (
+              <>
+                <p>{hierarchyItem.metadata?.treeChildCount} total sub-topics</p>
+                <p>{hierarchyItem.metadata?.treeConnectionHeight} levels deep</p>
+              </>
+            )}
+            {children}
+          </div>
+        ),
+      }}
     >
-      <summary className="a11ywb-accordion-header" 
-        onFocus={handleFocus}
-      >
-        {getItemLabel(hierarchyItem, { onFocus })}
-
-        <div className="a11ywb-board-item__metadata">
-          {metadata && (
-            <>
-              <p>{hierarchyItem.metadata?.treeChildCount} total sub-topics</p>
-              <p>{hierarchyItem.metadata?.treeConnectionHeight} levels deep</p>
-            </>
-          )}
-          {children}
-        </div>
-      </summary>
-
       <div className="a11ywb-accordion__contents">
         {listItems.length > 0 && (
           <ul>
@@ -270,7 +302,7 @@ const TreeBoardItem: React.FC<TreeBoardItemProps> = ({ hierarchyItem, subtype, c
         )}
         {listItems.length === 0 && <p>There are no child items.</p>}
       </div>
-    </details>
+    </Accordion>
   );
 };
 

--- a/src/components/hierarchy.tsx
+++ b/src/components/hierarchy.tsx
@@ -258,7 +258,12 @@ const BoardItem: React.FC<BoardItemProps<Item>> = ({ hierarchyItem, children }) 
   );
 };
 
-const TreeBoardItem: React.FC<TreeBoardItemProps> = ({ hierarchyItem, subtype, children, onFocus }) => {
+const TreeBoardItem: React.FC<TreeBoardItemProps> = ({
+  hierarchyItem,
+  subtype,
+  children,
+  onFocus,
+}) => {
   const listItems = hierarchyItem.children ?? [];
   const metadata = hierarchyItem.metadata;
 
@@ -427,7 +432,7 @@ const StickyNoteTypeBoardItem: React.FC<StickyNoteTypeBoardItemProps> = ({ hiera
   const colorKey = hierarchyItem.item?.style.fillColor;
   const colorLabel = getColorConfig(hierarchyItem.item)?.displayLabel;
 
-  const { onFocus } = useEarcon({ category: hierarchyItem.item })
+  const { onFocus } = useEarcon({ category: hierarchyItem.item });
 
   return (
     <TreeBoardItem hierarchyItem={hierarchyItem} onFocus={onFocus}>

--- a/src/components/titled-section.tsx
+++ b/src/components/titled-section.tsx
@@ -17,11 +17,7 @@ export const HeadingTagMap: Record<string, keyof JSX.IntrinsicElements> = {
   h6: 'h6',
 };
 
-const TitledSection: React.FC<TitledSectionProps> = ({
-  title,
-  headingLevel,
-  children,
-}) => {
+const TitledSection: React.FC<TitledSectionProps> = ({ title, headingLevel, children }) => {
   const HeadingTag = HeadingTagMap[headingLevel] as keyof JSX.IntrinsicElements;
   const headingId = title.replaceAll(' ', '_');
   return (

--- a/src/components/titled-section.tsx
+++ b/src/components/titled-section.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 
+export type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
 export interface TitledSectionProps {
   title: string;
-  headingLevel: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  headingLevel: HeadingLevel;
   children: React.ReactNode;
 }
 
-const HeadingTagMap: Record<string, keyof JSX.IntrinsicElements> = {
+export const HeadingTagMap: Record<string, keyof JSX.IntrinsicElements> = {
   h1: 'h1',
   h2: 'h2',
   h3: 'h3',

--- a/src/styles/components/accordion.css
+++ b/src/styles/components/accordion.css
@@ -1,11 +1,33 @@
 .a11ywb-accordion {
   border: 1px solid black;
   border-radius: 4px;
+  padding: 4px 8px;
+}
+
+.a11ywb-accordion-summary__button {
+  background-color: transparent;
+  border: none;
+  margin: 0;
+  padding: 0;
+  text-align: inherit;
+  font: inherit;
+  border-radius: 0;
+  appearance: none;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  margin-left: -8px;
+}
+
+.a11ywb-accordion-summary__button--open::before {
+  content: url('/src/assets/icons/arrow_drop_up.svg');
+}
+
+.a11ywb-accordion-summary__button--closed::before {
+  content: url('/src/assets/icons/arrow_right.svg');
 }
 
 .a11ywb-accordion-header {
-  padding: 4px 8px;
-
   h1,
   h2,
   h3,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
       "@utils/*": ["./src/utils/*"],
       "@data/*": ["./data/*"],
       "@audio": ["/src/assets/audio"],
+      "@icons": ["/src/assets/icons"]
     }
   },
   "include": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
       '@components': path.resolve(__dirname, './src/components'),
       '@utils': path.resolve(__dirname, './src/utils'),
       '@audio': path.resolve(__dirname, './src/assets/audio'),
+      '@icons': path.resolve(__dirname, './src/assets/icons'),
     },
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import dns from 'dns';
-import {defineConfig} from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/server-options.html#server-host
@@ -18,14 +18,11 @@ const collectHtmlEntries = (dir: string, prefix = '') =>
       if (fs.statSync(fullPath).isDirectory()) {
         Object.assign(acc, collectHtmlEntries(fullPath, `${prefix}${file}/`));
       } else if (path.extname(file) === '.html') {
-        acc[`${prefix}${path.basename(file, '.html')}`] = path.resolve(
-          __dirname,
-          fullPath
-        );
+        acc[`${prefix}${path.basename(file, '.html')}`] = path.resolve(__dirname, fullPath);
       }
       return acc;
     },
-    {} as Record<string, string>
+    {} as Record<string, string>,
   );
 
 const allHtmlEntries = collectHtmlEntries('.');


### PR DESCRIPTION
This creates a new Accordion component that we can use in favor of the native `details`/`summary` architecture for displaying board items.

Previously, we used a `details` element with a `summary` child element. The `summary` captured a heading, metadata, and buttons. Screen readers (notably NVDA) narrated all of this information, and that could be overwhelming for users.
<img width="336" height="173" alt="Screenshot of board item where the focus extends to the entire item" src="https://github.com/user-attachments/assets/11751d5b-eb2b-4e56-8915-6c39f1d51578" />

We could've moved the extraneous information out of the `summary` and directly into the `details` element itself, but this would've hidden information that we wanted to expose immediately to users.

This proposes a new structure based around an unfortunately less semantic `div` element with a `header` that represents the heading of the accordion. This text should be read aloud immediately, but the remaining text/buttons will be read later at user discretion.
<img width="336" height="173" alt="Screenshot of board item where the focus extends to only the heading text" src="https://github.com/user-attachments/assets/8a0d3877-5ea7-4464-a182-3df2e025ec0f" />
