### PR TITLE
Fix: Overlapping frames when creating

### DIFF
--- a/modals/components/AddModal.tsx
+++ b/modals/components/AddModal.tsx
@@ -7,6 +7,7 @@ import { parseFloatFromForm } from '@utils/forms';
 import { ConnectableItem, HierarchyItem } from '@models/item';
 import { isStickyNote } from '@utils/items';
 import { placeItem } from '@utils/item-placer';
+import { getFramePlacement } from '@utils/frame-placer';
 
 type AddModalProps = {
   handleError: (message: string, error: unknown) => void;
@@ -65,14 +66,20 @@ export const AddModal = (props: AddModalProps) => {
       }
 
       if (dataType === 'frame') {
+        const newFrameRect = await getFramePlacement({
+          x: 0,
+          y: 0,
+          width: newItemDimensions.width ?? 700,
+          height: newItemDimensions.height ?? 500,
+        });
+
         await miro.board.createFrame({
           title: formData.get('title') as string,
           style: {
             fillColor: (formData.get('style.fillColor') as string) ?? 'transparent',
           },
-          ...newItemDimensions,
-          x: 0, // for frames we might want to add it relative to the last created frame
-          y: 0,
+          ...newFrameRect,
+          relativeTo: 'canvas_center'
         });
       }
 

--- a/modals/components/EditModal.tsx
+++ b/modals/components/EditModal.tsx
@@ -3,7 +3,7 @@ import { Connector, Frame, Group, Item, Tag } from '@mirohq/websdk-types';
 import { FormEvent, useEffect, useState } from 'react';
 import { notifyBoardUpdate } from '../../src/utils/board-sync';
 import { InputElement } from '../inputs/InputElement';
-import { findFramePlacement, placeItem } from '@utils/item-placer';
+import { findBoardPlacement, placeItem } from '@utils/item-placer';
 import { isConnectableItem } from '@utils/items';
 import { HierarchyItem } from '@models/item';
 import { disconnectFromParent } from '@utils/connections';
@@ -84,7 +84,7 @@ export const EditModal = (props: EditModalProps) => {
           }
         } else {
           // center items in board
-          const emptySpot = await findFramePlacement({ 
+          const emptySpot = await findBoardPlacement({ 
             x: 0, 
             y: 0,
           });

--- a/src/config/placement.ts
+++ b/src/config/placement.ts
@@ -1,0 +1,23 @@
+export interface SpiralSearchOptions {
+    startingRingSize?: number;
+    ringMargin?: number;
+    maxRingCount?: number;
+}
+
+export const SPIRAL_SEARCH_DEFAULT_OPTIONS: Required<SpiralSearchOptions> = {
+    startingRingSize: 20,
+    ringMargin: 20,
+    maxRingCount: 10
+}
+
+export interface GridSearchOptions {
+    itemsPerRow?: number;
+    columnGap?: number;
+    rowGap?: number;
+}
+
+export const GRID_SEARCH_DEFAULT_OPTIONS: Required<GridSearchOptions> = {
+    itemsPerRow: 4,
+    columnGap: 20,
+    rowGap: 20,
+};

--- a/src/utils/canvas-items.ts
+++ b/src/utils/canvas-items.ts
@@ -1,6 +1,7 @@
 import { Frame, Rect } from "@mirohq/websdk-types";
 import { ConnectableItem } from "@models/item";
-import { getSpatialBounds, Position } from "./canvas-geometry";
+import { getAbsolutePosition, getSpatialBounds, Position } from "./canvas-geometry";
+import { isConnectableItem, isFrame } from "./items";
 
 export async function expandFrameTowardsItem(frame: Frame, item: Rect) {
     const frameBounds = getSpatialBounds(frame);
@@ -51,4 +52,32 @@ export function getSnapOffset(position: Position, item: ConnectableItem, snapTo?
         case 'right':  return { x: position.x + item.width * 0.5, y: position.y };
         default:       return position; // auto: todo: should calculate based on direction relative to counterpart
     }
+}
+
+export async function getToplevelRects(): Promise<Rect[]> {
+    const boardItems = await miro.board.get();
+    
+    const existingItems: Rect[] = boardItems
+        .map(boardItem => {
+            if (isConnectableItem(boardItem) && !boardItem.parentId) {
+                const absolutePosition = getAbsolutePosition(boardItem);
+                return {
+                    ...absolutePosition,
+                    width: boardItem.width,
+                    height: boardItem.height,
+                }
+
+            } else if (isFrame(boardItem)) {
+                const absolutePosition = { x: boardItem.x, y: boardItem.y };
+                return {
+                    ...absolutePosition,
+                    width: boardItem.width,
+                    height: boardItem.height,
+                }
+            } else {
+                return null;
+            }
+        }).filter(boardItem => !!boardItem);
+
+    return existingItems;
 }

--- a/src/utils/frame-placer.ts
+++ b/src/utils/frame-placer.ts
@@ -1,0 +1,32 @@
+import { Rect } from "@mirohq/websdk-types";
+import { findBoardPlacement } from "./item-placer";
+import { RelativeBounds } from "./canvas-geometry";
+import { getToplevelRects } from "./canvas-items";
+import { gridSearch } from "./placement-strategy";
+
+export interface FramePlacementOptions {
+    width?: number | null;
+    height?: number | null;
+    x?: number | null;
+    y?: number | null;
+}
+
+export async function getFramePlacement(frame: Rect, options: FramePlacementOptions = {}): Promise<RelativeBounds> {
+    const existingItems = await getToplevelRects();
+    
+    let spiralOrigin: RelativeBounds = { 
+        x: options.x ?? frame.x ?? 0, 
+        y: options.y ?? frame.y ?? 0, 
+        width: 10000, 
+        height: 10000, 
+        relativeTo: 'canvas_center' 
+    };
+
+    let futurePlacement = gridSearch(frame, existingItems, spiralOrigin);
+
+    if (!futurePlacement) {
+        futurePlacement = await findBoardPlacement(frame);
+    }
+
+    return futurePlacement;
+}

--- a/src/utils/item-placer.ts
+++ b/src/utils/item-placer.ts
@@ -4,7 +4,7 @@ import { ConnectableItem, HierarchyItem, HierarchyItemType } from "@models/item"
 import { isConnectableItem, isConnector, isFrame, isHierarchyItem } from "./items";
 import { canBeContainedIn, getAbsolutePosition, getSpatialBounds, Position, RelativeBounds } from "./canvas-geometry";
 import { spiralSearch } from "./placement-strategy";
-import { expandFrameTowardsItem, getSnapOffset } from "./canvas-items";
+import { expandFrameTowardsItem, getSnapOffset, getToplevelRects } from "./canvas-items";
 
 export interface ItemPlacementOptions {
     x?: number | null;
@@ -33,10 +33,10 @@ export async function getItemFrameId(
     return item.parentId;
 }
 
-export async function placeItem(item: ConnectableItem, options: ItemPlacementOptions = {}): Promise<void> {
+export async function placeItem(item: HierarchyItemType, options: ItemPlacementOptions = {}): Promise<void> {
     const { parent } = options;
 
-    if (isHierarchyItem(parent?.item)) {
+    if (isHierarchyItem(parent?.item) && isConnectableItem(item)) {
         let frame: Frame | undefined = undefined;
 
         const frameId = await getItemFrameId(item, { parent, frame: options.frame });
@@ -54,7 +54,7 @@ export async function placeItem(item: ConnectableItem, options: ItemPlacementOpt
 
         if (isConnectableItem(item)) {
             if (!futurePlacement) {
-                futurePlacement = await findFramePlacement(item);
+                futurePlacement = await findBoardPlacement(item);
             }
 
             const parentAbsolutePos = getAbsolutePosition(parent.item, frame);
@@ -90,8 +90,6 @@ export async function placeItem(item: ConnectableItem, options: ItemPlacementOpt
             if (frame) {
                 await frame.add(item);
             }
-        } else {
-            
         }
         
     } else { // board-level
@@ -101,7 +99,7 @@ export async function placeItem(item: ConnectableItem, options: ItemPlacementOpt
         });
 
         if (!futurePlacement) {
-            futurePlacement = await findFramePlacement(item);
+            futurePlacement = await findBoardPlacement(item);
         }
 
         item.x = futurePlacement.x;
@@ -111,34 +109,12 @@ export async function placeItem(item: ConnectableItem, options: ItemPlacementOpt
     }
 }
 
-export async function findFuturePlacement(item: ConnectableItem, options?: ItemPlacementOptions): Promise<RelativeBounds | null> {
+export async function findFuturePlacement(item: HierarchyItemType, options?: ItemPlacementOptions): Promise<RelativeBounds | null> {
     const { parent, frame } = options ?? {};
 
     // base case: board-level placement
     if (!frame && !parent) {
-        const boardItems = await miro.board.get();
-
-        const existingItems: Rect[] = boardItems
-            .map(boardItem => {
-                if (isConnectableItem(boardItem) && !boardItem.parentId) {
-                    const absolutePosition = getAbsolutePosition(boardItem);
-                    return {
-                        ...absolutePosition,
-                        width: boardItem.width,
-                        height: boardItem.height,
-                    }
-
-                } else if (isFrame(boardItem)) {
-                    const absolutePosition = { x: boardItem.x, y: boardItem.y };
-                    return {
-                        ...absolutePosition,
-                        width: boardItem.width,
-                        height: boardItem.height,
-                    }
-                } else {
-                    return null;
-                }
-            }).filter(boardItem => !!boardItem);
+        const existingItems = await getToplevelRects();
 
         let spiralOrigin: RelativeBounds = { 
             x: 0, 
@@ -214,7 +190,7 @@ export async function findFuturePlacement(item: ConnectableItem, options?: ItemP
     return null;
 };
 
-export async function findFramePlacement(options?: ItemPlacementOptions): Promise<RelativeBounds> {
+export async function findBoardPlacement(options?: ItemPlacementOptions): Promise<RelativeBounds> {
     const x = options?.x ?? 0;
     const y = options?.y ?? 0;
     const height = options?.height ?? 200; // todo: move to config

--- a/src/utils/item-placer.ts
+++ b/src/utils/item-placer.ts
@@ -43,69 +43,114 @@ export async function placeItem(item: ConnectableItem, options: ItemPlacementOpt
 
         if (frameId) {
             frame = await miro.board.getById(frameId) as Frame;
-
-            const futurePlacement = await findFuturePlacement(item, { 
-                width: item.width, 
-                height: item.height,
-                parent,
-                frame,
-            });
-
-            if (futurePlacement && isConnectableItem(item)) {
-                const parentAbsolutePos = getAbsolutePosition(parent.item, frame);
-                const parentRect = {
-                    x: parentAbsolutePos.x,
-                    y: parentAbsolutePos.y,
-                    height: parent.item.height,
-                    width: parent.item.width,
-                };
-
-                if (parent.id !== frameId) {
-                    // only add connectors if parent exists and is not a frame
-                    const connectorEndpoints = calculateConnectorEndpoints(parentRect, futurePlacement);
-
-                    await miro.board.createConnector({
-                        shape: 'curved',
-                        start: {
-                            item: parent.item.id,
-                            snapTo: connectorEndpoints.start.snapTo,
-                        },
-                        end: {
-                            item: item.id,
-                            snapTo: connectorEndpoints.end.snapTo,
-                        }
-                    });
-                }
-
-                item.x = futurePlacement.x;
-                item.y = futurePlacement.y;
-
-                await item.sync();
-                await frame.add(item);
-            } else {
-                // cannot add to frame, but we rearrange so it does not overlap other failed attempts
-
-                const emptySpot = await findFramePlacement(item);
-                item.x = emptySpot.x;
-                item.y = emptySpot.y;
-                await item.sync();
-            }
         }
+
+        let futurePlacement = await findFuturePlacement(item, { 
+            width: item.width, 
+            height: item.height,
+            parent,
+            frame,
+        });
+
+        if (isConnectableItem(item)) {
+            if (!futurePlacement) {
+                futurePlacement = await findFramePlacement(item);
+            }
+
+            const parentAbsolutePos = getAbsolutePosition(parent.item, frame);
+            const parentRect = {
+                x: parentAbsolutePos.x,
+                y: parentAbsolutePos.y,
+                height: parent.item.height,
+                width: parent.item.width,
+            };
+
+            if (isConnectableItem(parent.item) || parent.id !== frameId) {
+                // only add connectors if parent exists and is not a frame
+                const connectorEndpoints = calculateConnectorEndpoints(parentRect, futurePlacement);
+
+                await miro.board.createConnector({
+                    shape: 'curved',
+                    start: {
+                        item: parent.item.id,
+                        snapTo: connectorEndpoints.start.snapTo,
+                    },
+                    end: {
+                        item: item.id,
+                        snapTo: connectorEndpoints.end.snapTo,
+                    }
+                });
+            }
+
+            item.x = futurePlacement.x;
+            item.y = futurePlacement.y;
+
+            await item.sync();
+
+            if (frame) {
+                await frame.add(item);
+            }
+        } else {
+            
+        }
+        
+    } else { // board-level
+        let futurePlacement: Position | null = await findFuturePlacement(item, { 
+            width: item.width, 
+            height: item.height,
+        });
+
+        if (!futurePlacement) {
+            futurePlacement = await findFramePlacement(item);
+        }
+
+        item.x = futurePlacement.x;
+        item.y = futurePlacement.y;
+
+        await item.sync();
     }
 }
 
 export async function findFuturePlacement(item: ConnectableItem, options?: ItemPlacementOptions): Promise<RelativeBounds | null> {
     const { parent, frame } = options ?? {};
 
-    // base case, delegate to Miro's auto-placement
+    // base case: board-level placement
     if (!frame && !parent) {
-        const autoPosition = await miro.board.findEmptySpace(item);
-        
-        item.x = autoPosition.x;
-        item.y = autoPosition.y;
-        item.sync();
+        const boardItems = await miro.board.get();
 
-        return item;
+        const existingItems: Rect[] = boardItems
+            .map(boardItem => {
+                if (isConnectableItem(boardItem) && !boardItem.parentId) {
+                    const absolutePosition = getAbsolutePosition(boardItem);
+                    return {
+                        ...absolutePosition,
+                        width: boardItem.width,
+                        height: boardItem.height,
+                    }
+
+                } else if (isFrame(boardItem)) {
+                    const absolutePosition = { x: boardItem.x, y: boardItem.y };
+                    return {
+                        ...absolutePosition,
+                        width: boardItem.width,
+                        height: boardItem.height,
+                    }
+                } else {
+                    return null;
+                }
+            }).filter(boardItem => !!boardItem);
+
+        let spiralOrigin: RelativeBounds = { 
+            x: 0, 
+            y: 0, 
+            width: 10000, 
+            height: 10000, 
+            relativeTo: 'canvas_center' 
+        };
+
+        const attemptBounds = spiralSearch(item, existingItems, spiralOrigin);
+
+        return attemptBounds;
     }
 
     // case 2: frame parent, no connectors
@@ -169,7 +214,7 @@ export async function findFuturePlacement(item: ConnectableItem, options?: ItemP
     return null;
 };
 
-export async function findFramePlacement(options?: ItemPlacementOptions): Promise<{ x: number; y: number }> {
+export async function findFramePlacement(options?: ItemPlacementOptions): Promise<RelativeBounds> {
     const x = options?.x ?? 0;
     const y = options?.y ?? 0;
     const height = options?.height ?? 200; // todo: move to config
@@ -186,6 +231,9 @@ export async function findFramePlacement(options?: ItemPlacementOptions): Promis
     return {
         x: candidateEmptySpace.x,
         y: candidateEmptySpace.y,
+        height,
+        width,
+        relativeTo: 'canvas_center',
     };
 };
 

--- a/src/utils/placement-strategy.ts
+++ b/src/utils/placement-strategy.ts
@@ -1,19 +1,10 @@
 import { Rect } from "@mirohq/websdk-types";
 import { isOverlapping, RelativeBounds } from "./canvas-geometry";
+import { GRID_SEARCH_DEFAULT_OPTIONS, GridSearchOptions, SPIRAL_SEARCH_DEFAULT_OPTIONS, SpiralSearchOptions } from "@config/placement";
 
-export interface SpiralSearchOptions {
-    startingRingSize?: number;
-    ringMargin?: number;
-    maxRingCount?: number;
-}
-
-export const SPIRAL_SEARCH_DEFAULT_OPTIONS: Required<SpiralSearchOptions> = {
-    startingRingSize: 20,
-    ringMargin: 20,
-    maxRingCount: 10
-}
-
-// assumed all item positions are absolute
+/**
+ * Find a non-occupied space to place an item following a clockwise radial/spiral order. Each ring could accommodate around 8 items.
+ */
 export function spiralSearch(item: Rect, existingItems: Rect[], origin: RelativeBounds, options?: SpiralSearchOptions): RelativeBounds | null {
     if (!existingItems?.length) {
         return origin;
@@ -41,7 +32,7 @@ export function spiralSearch(item: Rect, existingItems: Rect[], origin: Relative
             // avoid making a grid-like alignment
             const sliceAngle = (2 * Math.PI) / ringSliceCount;
             const ringOffset = ((ringIndex + 1) % 2) * sliceAngle * 0.5;
-            const angle = ringOffset + ((Math.PI / 2) - (sliceIndex / ringSliceCount) * 2 * Math.PI);
+            const angle = ringOffset - (Math.PI / 2) + sliceIndex * sliceAngle;
 
             // NOTE: leaving this commented for now, not sure if we want this optimization
             //
@@ -83,19 +74,10 @@ export function spiralSearch(item: Rect, existingItems: Rect[], origin: Relative
     return lastAttempt;
 }
 
-export interface GridSearchOptions {
-    itemsPerRow?: number;
-    columnGap?: number;
-    rowGap?: number;
-}
-
-export const GRID_SEARCH_DEFAULT_OPTIONS: Required<GridSearchOptions> = {
-    itemsPerRow: 4,
-    columnGap: 20,
-    rowGap: 20,
-};
-
-// assumed all item positions are absolute
+/**
+ * Find a non-occupied space to place an item following a top-bottom left-right order.
+ * By default, each row contains 4 items
+ */
 export function gridSearch(
     item: Rect,
     existingItems: Rect[],

--- a/src/utils/placement-strategy.ts
+++ b/src/utils/placement-strategy.ts
@@ -82,3 +82,54 @@ export function spiralSearch(item: Rect, existingItems: Rect[], origin: Relative
     // giving up
     return lastAttempt;
 }
+
+export interface GridSearchOptions {
+    itemsPerRow?: number;
+    columnGap?: number;
+    rowGap?: number;
+}
+
+export const GRID_SEARCH_DEFAULT_OPTIONS: Required<GridSearchOptions> = {
+    itemsPerRow: 4,
+    columnGap: 20,
+    rowGap: 20,
+};
+
+// assumed all item positions are absolute
+export function gridSearch(
+    item: Rect,
+    existingItems: Rect[],
+    origin: RelativeBounds,
+    options?: GridSearchOptions
+): RelativeBounds | null {
+    const itemsPerRow = options?.itemsPerRow ?? GRID_SEARCH_DEFAULT_OPTIONS.itemsPerRow;
+    const columnGap = options?.columnGap ?? GRID_SEARCH_DEFAULT_OPTIONS.columnGap;
+    const rowGap = options?.rowGap ?? GRID_SEARCH_DEFAULT_OPTIONS.rowGap;
+
+    const cellWidth = item.width + columnGap;
+    const cellHeight = item.height + rowGap;
+
+    // Grid expands row by row
+    const maxRows = Math.ceil((existingItems.length + 1) / itemsPerRow) + 1;
+
+    for (let row = 0; row < maxRows; row++) {
+        for (let col = 0; col < itemsPerRow; col++) {
+            const candidate: RelativeBounds = {
+                relativeTo: origin.relativeTo,
+                x: origin.x + col * cellWidth,
+                y: origin.y + row * cellHeight,
+                width: item.width,
+                height: item.height,
+            };
+
+            const isFreeSpace = !existingItems.length ||
+                existingItems.every(existing => !isOverlapping(existing, candidate));
+
+            if (isFreeSpace) {
+                return candidate;
+            }
+        }
+    }
+
+    return null;
+}


### PR DESCRIPTION
# Overview
Frames should now follow a grid placement strategy when creating from the prototype to avoid overlapping.

## Additional fixes
Fixed overlapping when sticky notes and text items are created in the board level.

<img width="496" height="364" alt="Screenshot 2026-05-10 at 16 09 02" src="https://github.com/user-attachments/assets/28779f9d-57e3-4439-8e5c-841eb964d530" />

